### PR TITLE
Attempt to fix GitHub Actions pipeline

### DIFF
--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -7,14 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - name: Publish React component
+        uses: actions/setup-node@v3
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@performant-software'
-      - run: cd editioncrafter
-      - run: npm ci
-      - run: npm publish --access public
+        run: cd editioncrafter && npm ci && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The previous version attempted to run a `cd` command to get into the package directory, which apparently you can't do in a GitHub Action. This PR refactors the Actions code in a way that will hopefully work.