### PR TITLE
Update package names

### DIFF
--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -17,6 +17,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish UMD build
-        run: cd editioncrafter-umd && npm ci && npm build && npm publish --access public
+        run: cd editioncrafter-umd && npm ci && npm run build && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/editioncrafter-umd/package.json
+++ b/editioncrafter-umd/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@performant-software/edition-crafter-umd",
+  "name": "@performant-software/editioncrafter-umd",
   "version": "0.0.3",
   "description": "",
   "private": false,

--- a/editioncrafter/package.json
+++ b/editioncrafter/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@performant-software/edition-crafter",
+  "name": "@performant-software/editioncrafter",
   "version": "0.0.3",
   "description": "",
   "private": false,


### PR DESCRIPTION
# Summary

- updates both packages to use `editioncrafter` instead of `edition-crafter` in their names (this will change their NPM links)
- fixes a typo in the UMD package's pipeline