### PR TITLE
Rescope package to `cu-mkp`

### DIFF
--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -11,12 +11,12 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-          scope: '@performant-software'
+          scope: '@cu-mkp'
       - name: Publish React component
-        run: cd editioncrafter && npm ci && npm publish --access public
+        run: cd editioncrafter && npm install && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish UMD build
-        run: cd editioncrafter-umd && npm ci && npm run build && npm publish --access public
+        run: cd editioncrafter-umd && npm install && npm update @cu-mkp/editioncrafter && npm run build && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DOI](https://zenodo.org/badge/574677398.svg)](https://zenodo.org/badge/latestdoi/574677398)
+
 # editioncrafter
 UNDER DEVELOPMENT: Software for the development of EditionCrafter, digital critical edition publication tool
 

--- a/editioncrafter-umd/package.json
+++ b/editioncrafter-umd/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@performant-software/editioncrafter-umd",
+  "name": "@cu-mkp/editioncrafter-umd",
   "version": "0.0.4",
   "description": "",
   "private": false,
@@ -14,7 +14,7 @@
   "license": "MIT",
   "repository": "https://github.com/cu-mkp/editioncrafter",
   "dependencies": {
-    "@performant-software/editioncrafter": "^0.0.4",
+    "@cu-mkp/editioncrafter": "^0.0.4",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"
   },

--- a/editioncrafter-umd/package.json
+++ b/editioncrafter-umd/package.json
@@ -9,7 +9,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "webpack build --mode=production"
+    "build": "webpack build --mode=production",
+    "prepublishOnly": "npm update @cu-mkp/editioncrafter && npm run build"
   },
   "license": "MIT",
   "repository": "https://github.com/cu-mkp/editioncrafter",

--- a/editioncrafter-umd/src/EditionCrafter.js
+++ b/editioncrafter-umd/src/EditionCrafter.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import EditionCrafterComponent from '@performant-software/editioncrafter';
+import EditionCrafterComponent from '@cu-mkp/editioncrafter';
 
 /**
  * Default instantiation

--- a/editioncrafter/package.json
+++ b/editioncrafter/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@performant-software/editioncrafter",
+  "name": "@cu-mkp/editioncrafter",
   "version": "0.0.4",
   "description": "",
   "private": false,

--- a/editioncrafter/src/globals.d.ts
+++ b/editioncrafter/src/globals.d.ts
@@ -1,1 +1,1 @@
-declare module '@performant-software/editioncrafter'
+declare module '@cu-mkp/editioncrafter'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@performant-software/edition-crafter-monorepo",
+  "name": "@cu-mkp/edition-crafter-monorepo",
   "description": "",
   "private": true,
   "scripts": {


### PR DESCRIPTION
This PR renames the packages to use the `@cu-mkp` scope.

It also slightly tweaks the GitHub pipeline to be more stable (using `npm install` instead of `npm ci`, which is too brittle in our situation).