### PR TITLE
Fix book mode and navbar display

### DIFF
--- a/editioncrafter/src/action/DocumentActions.js
+++ b/editioncrafter/src/action/DocumentActions.js
@@ -6,6 +6,7 @@ const textPartialResourceProfileID = 'https://github.com/cu-mkp/editioncrafter-p
 DocumentActions.loadDocument = function loadDocument(state, manifestData) {
   const folios = parseManifest(manifestData, state.transcriptionTypes);
   const { folioIndex, folioByName } = createFolioIndex(folios);
+
   return {
     ...state,
     loaded: true,
@@ -15,7 +16,7 @@ DocumentActions.loadDocument = function loadDocument(state, manifestData) {
   };
 };
 
-DocumentActions.loadFolio = function loadFolio( state, folio ) {
+DocumentActions.loadFolio = function loadFolio(state, folio) {
   const oldFolio = state.folioIndex[folio.id];
   const folioIdx = state.folios.indexOf(oldFolio);
   state.folios[folioIdx] = folio;
@@ -23,8 +24,8 @@ DocumentActions.loadFolio = function loadFolio( state, folio ) {
   state.folioByName[folio.name] = folio;
   return {
     ...state,
-  }
-}
+  };
+};
 
 function createFolioIndex(folios) {
   // Store an ordered array of folio ids, used for next/prev navigation purposes later

--- a/editioncrafter/src/component/DocumentView.js
+++ b/editioncrafter/src/component/DocumentView.js
@@ -76,22 +76,19 @@ class DocumentView extends Component {
     }
   }
 
-  findBookFolios(shortID) {
+  findBookFolios(folioID) {
     const { document } = this.props;
+    const versoFolio = document.folioIndex[folioID];
+    const { name, pageNumber } = versoFolio;
 
-    const versoFolio = document.folioNameByIDIndex[shortID];
-    let versoIndex = document.folioIndex.indexOf(shortID);
-
-    if (!versoFolio.endsWith('v')) {
-      if (versoFolio.endsWith('r')) {
-        versoIndex -= 1;
-      } else {
-        return [null, null];
+    if (!name.endsWith('v')) {
+      if (name.endsWith('r')) {
+        return [document.folios[pageNumber - 1].id, document.folios[pageNumber].id];
       }
+      return [null, null];
     }
 
-    const rectoIndex = versoIndex + 1;
-    return [document.folioIndex[versoIndex], document.folioIndex[rectoIndex]];
+    return [document.folios[pageNumber].id, document.folios[pageNumber + 1].id];
   }
 
   onWidth = (left, right) => {
@@ -286,6 +283,7 @@ class DocumentView extends Component {
     if (this.state.bookMode) {
       const [versoID] = this.findBookFolios(shortID);
       const current_idx = doc.folioIndex[versoID].pageNumber;
+
       if (current_idx > -1) {
         current_hasNext = (current_idx < (folioCount - 2));
         nextID = current_hasNext ? doc.folios[current_idx + 2].id : '';

--- a/editioncrafter/src/component/DocumentView.js
+++ b/editioncrafter/src/component/DocumentView.js
@@ -316,7 +316,7 @@ class DocumentView extends Component {
     const viewType = this.determineViewType(side);
     const key = this.viewPaneKey(side);
     const folioID = docView[side].iiifShortID;
-    let transcriptionType = docView[side].transcriptionType;
+    const { transcriptionType } = docView[side];
 
     if (viewType === 'ImageView') {
       return (

--- a/editioncrafter/src/component/ImageView.js
+++ b/editioncrafter/src/component/ImageView.js
@@ -57,11 +57,7 @@ class ImageView extends Component {
   render() {
     const { document, folioID, side } = this.props;
     const folio = document.folioIndex[folioID];
-    // if( folio.loading ) {
-    //   window.loadingModal_start();
-    // } else {
-    //   window.loadingModal_stop();
-    // }
+
     return (
       <div>
         { folio.tileSource

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import {
   FaArrowCircleLeft,
-  FaArrowCircleRight
+  FaArrowCircleRight,
 } from 'react-icons/fa';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -50,7 +50,7 @@ class Navigation extends React.Component {
   };
 
   toggleBookmode = function toggleBookmode(event) {
-    if (!this.props.documentView.bookMode === true) {
+    if (!this.props.documentView.bookMode) {
       this.props.documentViewActions.changeCurrentFolio(
         this.props.documentView.left.iiifShortID,
         'left',
@@ -131,7 +131,9 @@ class Navigation extends React.Component {
   };
 
   render() {
-    const { side, document, documentView, documentViewActions, onFilterChange } = this.props;
+    const {
+      side, document, documentView, documentViewActions, onFilterChange,
+    } = this.props;
 
     if (!documentView) {
       return (

--- a/editioncrafter/src/component/Pagination.js
+++ b/editioncrafter/src/component/Pagination.js
@@ -22,6 +22,7 @@ class Pagination extends React.Component {
     }
 
     const folioID = dataset.id;
+
     documentViewActions.changeCurrentFolio(
       folioID,
       side,

--- a/editioncrafter/src/component/TranscriptionView.js
+++ b/editioncrafter/src/component/TranscriptionView.js
@@ -66,7 +66,7 @@ class TranscriptionView extends Component {
           <div className="transcriptContent">
             <ErrorBoundary>
               <div
-                className='surface grid-mode'
+                className="surface grid-mode"
                 style={surfaceStyle}
               >
                 {Parser(html, htmlToReactParserOptionsSide)}

--- a/editioncrafter/src/component/Watermark.js
+++ b/editioncrafter/src/component/Watermark.js
@@ -4,7 +4,9 @@ import Pagination from './Pagination';
 
 const Watermark = ({ side, documentView, documentViewActions }) => (
   <div>
-    <Navigation side={side} documentView={documentView} documentViewActions={documentViewActions} />
+    { documentView.left.iiifShortID !== '-1' && documentView.right.iiifShortID !== '-1'
+      ? <Navigation side={side} documentView={documentView} documentViewActions={documentViewActions} />
+      : null}
     <div className="transcriptContent">
       <Pagination side={side} className="pagination_upper" documentView={documentView} documentViewActions={documentViewActions} />
       <div className="watermark">

--- a/editioncrafter/src/component/XMLView.js
+++ b/editioncrafter/src/component/XMLView.js
@@ -14,7 +14,6 @@ class XMLView extends Component {
     const thisClass = `xmlViewComponent ${side}`;
     const thisID = `xmlViewComponent_${side}`;
 
-    console.log(documentView);
     // Retrofit - the folios are loaded asynchronously
     const folioID = documentView[side].iiifShortID;
     if (folioID === '-1') {

--- a/editioncrafter/src/component/XMLView.js
+++ b/editioncrafter/src/component/XMLView.js
@@ -14,6 +14,7 @@ class XMLView extends Component {
     const thisClass = `xmlViewComponent ${side}`;
     const thisID = `xmlViewComponent_${side}`;
 
+    console.log(documentView);
     // Retrofit - the folios are loaded asynchronously
     const folioID = documentView[side].iiifShortID;
     if (folioID === '-1') {

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -4,7 +4,6 @@ import EditionCrafter from '../src/index';
 import './assets/editioncrafter.css';
 
 const config = {
-  id: 'ec',
   iiifManifest: 'http://localhost:8080/fr640_3r-3v-example/iiif/manifest.json',
   documentName: 'BnF Ms. Fr. 640',
   transcriptionTypes: {


### PR DESCRIPTION
# Summary

- fixes book mode by updating the `findBookFolios` method from `DocumentView` to use the newly refactored `DocumentActions`
- updates the `watermark` method in `TranscriptionView` to hide the navbar when there's no folio selected in either pane
- various linting fixes

Closes #19