### PR TITLE
Fix XML mode and remaining React warnings

### DIFF
--- a/editioncrafter/src/component/DocumentView.js
+++ b/editioncrafter/src/component/DocumentView.js
@@ -317,9 +317,10 @@ class DocumentView extends Component {
   renderPane(side, docView) {
     const viewType = this.determineViewType(side);
     const key = this.viewPaneKey(side);
+    const folioID = docView[side].iiifShortID;
+    let transcriptionType = docView[side].transcriptionType;
 
     if (viewType === 'ImageView') {
-      const folioID = docView[side].iiifShortID;
       return (
         <ImageView
           key={key}
@@ -330,8 +331,6 @@ class DocumentView extends Component {
         />
       );
     } if (viewType === 'TranscriptionView') {
-      const folioID = docView[side].iiifShortID;
-      let transcriptionType = docView[side].transcriptionType;
       return (
         <TranscriptionView
           key={key}
@@ -346,6 +345,8 @@ class DocumentView extends Component {
       return (
         <XMLView
           key={key}
+          folioID={folioID}
+          transcriptionType={transcriptionType}
           documentView={docView}
           documentViewActions={this.documentViewActions}
           side={side}

--- a/editioncrafter/src/component/ImageGridView.js
+++ b/editioncrafter/src/component/ImageGridView.js
@@ -14,14 +14,13 @@ class ImageGridView extends React.Component {
     };
   }
 
-  // TODO REFACTOR
-  UNSAFE_componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     const { documentView } = this.props;
     const folioID = documentView[this.props.side].iiifShortID;
-    const nextFolioID = nextProps.documentView[this.props.side].iiifShortID;
+    const nextFolioID = this.props.documentView[this.props.side].iiifShortID;
 
     if (folioID !== nextFolioID) {
-      const thumbs = this.generateThumbs(nextFolioID, nextProps.document.folios);
+      const thumbs = this.generateThumbs(nextFolioID, this.props.document.folios);
       const thumbCount = (thumbs.length > this.loadIncrement) ? this.loadIncrement : thumbs.length;
       const visibleThumbs = thumbs.slice(0, thumbCount);
       this.setState({ thumbs, visibleThumbs });

--- a/editioncrafter/src/component/JumpToFolio.js
+++ b/editioncrafter/src/component/JumpToFolio.js
@@ -23,9 +23,9 @@ class JumpToFolio extends React.Component {
     this.setState({ textInput: '' });
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     // FIXME: this is an over-clever hack, but how else do you force focus?
-    if (nextProps.isVisible) {
+    if (this.props.isVisible) {
       const script = document.createElement('script');
       const id = `${this.props.side}_jumpInput`;
       script.innerHTML = `setTimeout(function() { document.getElementById('${id}').focus(); }, 250);`;
@@ -40,7 +40,7 @@ class JumpToFolio extends React.Component {
 
   render() {
     const divStyle = {
-	  		position: 'fixed',
+      position: 'fixed',
       zIndex: 1,
       top: this.props.positionY,
       left: this.props.positionX,

--- a/editioncrafter/src/component/TranscriptionView.js
+++ b/editioncrafter/src/component/TranscriptionView.js
@@ -5,6 +5,7 @@ import Navigation from './Navigation';
 import Pagination from './Pagination';
 import EditorComment from './EditorComment';
 import ErrorBoundary from './ErrorBoundary';
+import Watermark from './Watermark';
 
 class TranscriptionView extends Component {
   // Recursively unpack a node tree object and just return the text
@@ -27,12 +28,24 @@ class TranscriptionView extends Component {
     } = this.props;
 
     if (folioID === '-1') {
-      return watermark(documentView, documentViewActions, side);
+      return (
+        <Watermark
+          documentView={documentView}
+          documentViewActions={documentViewActions}
+          side={side}
+        />
+      );
     }
 
     const folio = document.folioIndex[folioID];
     if (!folio.transcription) {
-      return watermark(documentView, documentViewActions, side);
+      return (
+        <Watermark
+          documentView={documentView}
+          documentViewActions={documentViewActions}
+          side={side}
+        />
+      );
     }
     const transcriptionData = folio.transcription[transcriptionType];
 
@@ -90,20 +103,6 @@ function htmlToReactParserOptions() {
     },
   };
   return parserOptions;
-}
-
-function watermark(documentView, documentViewActions, side) {
-  return (
-    <div>
-        <Navigation side={side} documentView={documentView} documentViewActions={documentViewActions} />
-        <div className="transcriptContent">
-          <Pagination side={side} className="pagination_upper" documentView={documentView} documentViewActions={documentViewActions} />
-          <div className="watermark">
-            <div className="watermark_contents" />
-          </div>
-        </div>
-    </div>
-  );
 }
 
 function mapStateToProps(state) {

--- a/editioncrafter/src/component/Watermark.js
+++ b/editioncrafter/src/component/Watermark.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import Navigation from './Navigation';
+import Pagination from './Pagination';
+
+const Watermark = ({ side, documentView, documentViewActions }) => (
+  <div>
+    <Navigation side={side} documentView={documentView} documentViewActions={documentViewActions} />
+    <div className="transcriptContent">
+      <Pagination side={side} className="pagination_upper" documentView={documentView} documentViewActions={documentViewActions} />
+      <div className="watermark">
+        <div className="watermark_contents" />
+      </div>
+    </div>
+  </div>
+);
+
+export default Watermark;

--- a/editioncrafter/src/component/XMLView.js
+++ b/editioncrafter/src/component/XMLView.js
@@ -31,27 +31,27 @@ class XMLView extends Component {
     });
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    // Refresh the content if there is an incoming change
-    let contentChange = false;
-    const newFolioID = this.props.documentView[this.props.side].iiifShortID;
+  // componentDidUpdate(prevProps, prevState) {
+  //   // Refresh the content if there is an incoming change
+  //   let contentChange = false;
+  //   const newFolioID = this.props.documentView[this.props.side].iiifShortID;
 
-    if (prevState.currentlyLoaded !== newFolioID) {
-      contentChange = true;
-      this.loadFolio(this.props.document.folioIndex[newFolioID]);
-    }
+  //   if (prevState.currentlyLoaded !== newFolioID) {
+  //     contentChange = true;
+  //     this.loadFolio(this.props.document.folioIndex[newFolioID]);
+  //   }
 
-    // TODO make this work for XML view
-    if (contentChange) {
-      // Scroll content to top
-      const selector = `xmlViewComponent_${this.props.side}`;
-      const el = document.getElementById(selector);
-      if (el !== null) {
-        // console.log(selector + "scroll to top");
-        el.scrollTop = 0;
-      }
-    }
-  }
+  //   // TODO make this work for XML view
+  //   if (contentChange) {
+  //     // Scroll content to top
+  //     const selector = `xmlViewComponent_${this.props.side}`;
+  //     const el = document.getElementById(selector);
+  //     if (el !== null) {
+  //       // console.log(selector + "scroll to top");
+  //       el.scrollTop = 0;
+  //     }
+  //   }
+  // }
 
   // RENDER
   render() {
@@ -70,18 +70,16 @@ class XMLView extends Component {
           <div className="watermark_contents" />
         </div>
       );
-    } if (!this.state.isLoaded) {
-      this.loadFolio(document.folioIndex[folioID]);
-      return (
-        <div className="watermark">
-          <div className="watermark_contents" />
-        </div>
-      );
+    } 
+
+    const folio = document.folioIndex[folioID];
+    if (!folio.transcription) {
+      return watermark(documentView, documentViewActions, side);
     }
 
-    // get the xml for this transcription
     const { transcriptionType } = documentView[side];
-    const xmlContent = this.state.folio.transcription ? this.state.folio.transcription[transcriptionType].xml : '';
+    const transcriptionData = folio.transcription[transcriptionType];
+    const { xml: xmlContent } = transcriptionData;
 
     return (
       <div id={thisID} className={thisClass}>

--- a/editioncrafter/src/component/XMLView.js
+++ b/editioncrafter/src/component/XMLView.js
@@ -16,6 +16,7 @@ class XMLView extends Component {
       // console.log("TranscriptView: Folio is undefined when you called loadFolio()!");
       return;
     }
+    console.log('calling downloadFolio');
     downloadFolio(folio).then((data) => {
       const folioID = documentView[side].iiifShortID;
       this.setState({
@@ -30,14 +31,14 @@ class XMLView extends Component {
     });
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps, prevState) {
     // Refresh the content if there is an incoming change
     let contentChange = false;
-    const nextFolioID = this.props.documentView[this.props.side].iiifShortID;
-    if (this.state.currentlyLoaded !== nextFolioID) {
+    const newFolioID = this.props.documentView[this.props.side].iiifShortID;
+
+    if (prevState.currentlyLoaded !== newFolioID) {
       contentChange = true;
-      console.log(nextFolioID);
-      this.loadFolio(this.props.document.folioIndex[nextFolioID]);
+      this.loadFolio(this.props.document.folioIndex[newFolioID]);
     }
 
     // TODO make this work for XML view
@@ -80,22 +81,17 @@ class XMLView extends Component {
 
     // get the xml for this transcription
     const { transcriptionType } = documentView[side];
-    let xmlContent = '';
-    if (this.state.folio.transcription) {
-      xmlContent = this.state.folio.transcription[transcriptionType].html;
-    }
+    const xmlContent = this.state.folio.transcription ? this.state.folio.transcription[transcriptionType].xml : '';
 
     return (
       <div id={thisID} className={thisClass}>
         <Navigation side={side} documentView={documentView} documentViewActions={documentViewActions} />
-        <div className="xmlContent">
-          <Pagination side={side} className="pagination_upper" documentView={documentView} documentViewActions={documentViewActions} />
+        <Pagination side={side} className="pagination_upper" documentView={documentView} documentViewActions={documentViewActions} />
 
-          <div className="xmlContentInner">
-            <pre>{xmlContent}</pre>
-          </div>
-
+        <div className="xmlContentInner">
+          <pre>{xmlContent}</pre>
         </div>
+
       </div>
     );
   }

--- a/editioncrafter/src/component/XMLView.js
+++ b/editioncrafter/src/component/XMLView.js
@@ -2,57 +2,9 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Navigation from './Navigation';
 import Pagination from './Pagination';
-import { loadFolio as downloadFolio } from '../model/Folio';
+import Watermark from './Watermark';
 
 class XMLView extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { folio: [], isLoaded: false, currentlyLoaded: '' };
-  }
-
-  loadFolio(folio) {
-    const { side, documentView } = this.props;
-    if (typeof folio === 'undefined') {
-      // console.log("TranscriptView: Folio is undefined when you called loadFolio()!");
-      return;
-    }
-    console.log('calling downloadFolio');
-    downloadFolio(folio).then((data) => {
-      const folioID = documentView[side].iiifShortID;
-      this.setState({
-        folio: data,
-        isLoaded: true,
-        currentlyLoaded: folioID,
-      });
-      // this.forceUpdate();
-    }, (error) => {
-      console.log(`Unable to load transcription: ${error}`);
-      // this.forceUpdate();
-    });
-  }
-
-  // componentDidUpdate(prevProps, prevState) {
-  //   // Refresh the content if there is an incoming change
-  //   let contentChange = false;
-  //   const newFolioID = this.props.documentView[this.props.side].iiifShortID;
-
-  //   if (prevState.currentlyLoaded !== newFolioID) {
-  //     contentChange = true;
-  //     this.loadFolio(this.props.document.folioIndex[newFolioID]);
-  //   }
-
-  //   // TODO make this work for XML view
-  //   if (contentChange) {
-  //     // Scroll content to top
-  //     const selector = `xmlViewComponent_${this.props.side}`;
-  //     const el = document.getElementById(selector);
-  //     if (el !== null) {
-  //       // console.log(selector + "scroll to top");
-  //       el.scrollTop = 0;
-  //     }
-  //   }
-  // }
-
   // RENDER
   render() {
     const {
@@ -70,11 +22,17 @@ class XMLView extends Component {
           <div className="watermark_contents" />
         </div>
       );
-    } 
+    }
 
     const folio = document.folioIndex[folioID];
     if (!folio.transcription) {
-      return watermark(documentView, documentViewActions, side);
+      return (
+        <Watermark
+          documentView={documentView}
+          documentViewActions={documentViewActions}
+          side={side}
+        />
+      );
     }
 
     const { transcriptionType } = documentView[side];

--- a/editioncrafter/src/component/XMLView.js
+++ b/editioncrafter/src/component/XMLView.js
@@ -17,7 +17,6 @@ class XMLView extends Component {
       return;
     }
     downloadFolio(folio).then((data) => {
-      console.log(data);
       const folioID = documentView[side].iiifShortID;
       this.setState({
         folio: data,

--- a/editioncrafter/src/model/Folio.js
+++ b/editioncrafter/src/model/Folio.js
@@ -33,12 +33,9 @@ export function loadFolio(folioData) {
           ) => {
             const transcription = parseTranscription(htmlResponse.data, xmlResponse.data);
             if (!transcription) {
-              console.log('transcription not found');
               reject(new Error(`Unable to load transcription: ${htmlURL}`));
             } else {
-              console.log('transcription found');
               folio.transcription[transcriptionType] = transcription;
-              console.log(folio);
               folio.loading = false;
               resolve(folio);
             }

--- a/editioncrafter/src/model/Folio.js
+++ b/editioncrafter/src/model/Folio.js
@@ -33,9 +33,12 @@ export function loadFolio(folioData) {
           ) => {
             const transcription = parseTranscription(htmlResponse.data, xmlResponse.data);
             if (!transcription) {
+              console.log('transcription not found');
               reject(new Error(`Unable to load transcription: ${htmlURL}`));
             } else {
+              console.log('transcription found');
               folio.transcription[transcriptionType] = transcription;
+              console.log(folio);
               folio.loading = false;
               resolve(folio);
             }

--- a/editioncrafter/src/scss/_xmlView.scss
+++ b/editioncrafter/src/scss/_xmlView.scss
@@ -1,7 +1,7 @@
 .xmlViewComponent .navigationComponent {
   background-color: white;
   color: #000000; }
-  
+
 .xmlContent {
   padding: 0;
   margin: 4.5rem 0 0;
@@ -15,11 +15,15 @@
  }
 
 .xmlViewComponent {
-  overflow: scroll;
+  overflow: auto;
   margin: 0 0 0 1rem;
   height: calc(100vh - 7rem);
 }
 
 .xmlContentInner {
-  overflow-x: scroll;
+  max-height: 100%;
+}
+
+.xmlContentInner pre {
+  overflow-x: auto;
 }

--- a/editioncrafter/stories/assets/editioncrafter.css
+++ b/editioncrafter/stories/assets/editioncrafter.css
@@ -1181,13 +1181,17 @@ figure.current {
 }
 
 .xmlViewComponent {
-  overflow: scroll;
+  overflow: auto;
   margin: 0 0 0 1rem;
   height: calc(100vh - 7rem);
 }
 
 .xmlContentInner {
-  overflow-x: scroll;
+  max-height: 100%;
+}
+
+.xmlContentInner pre {
+  overflow-x: auto;
 }
 
 #glossaryView #glossaryViewInner {


### PR DESCRIPTION
# Summary

- fixes XML mode by updating its logic to account for the refactoring of `DocumentActions`, etc.
  - only two pages in the sample manifest have transcriptions so this was difficult to test locally, but toggling XML mode on/off and moving between pages seemed to work
- migrates the remaining occurrences of `componentWillReceiveProps` to `componentDidUpdate`, including the one that emitted a warning and two that had been prefixed with `UNSAFE` but had comments indicating that they should be refactored too
  - I know that `componentDidUpdate` has slightly different behavior than `componentWillReceiveProps`, but I tested each component while making the change and didn't notice any behavior changes. This should definitely be tested again by someone who's more familiar with EC and more able to notice minor changes.
  - refactors the watermark into its own component file now that it's shared between two other components

Closes #18 
Closes #21