### PR TITLE
Don't hardcode default `tl` transcription type

### DIFF
--- a/editioncrafter/src/component/DocumentView.js
+++ b/editioncrafter/src/component/DocumentView.js
@@ -127,7 +127,9 @@ class DocumentView extends Component {
     const {
       folioID, transcriptionType, folioID2, transcriptionType2,
     } = this.props.router.params;
+    const { document } = this.props;
     let viewports;
+    const firstTranscriptionType = Object.keys(document.transcriptionTypes)[0];
 
     if (!folioID) {
       // route /folios
@@ -138,7 +140,7 @@ class DocumentView extends Component {
         },
         right: {
           folioID: '-1',
-          transcriptionType: 'tl',
+          transcriptionType: firstTranscriptionType,
         },
       };
     } else {
@@ -149,13 +151,13 @@ class DocumentView extends Component {
         // route /ec/:folioID/:transcriptionType/:folioID2/:transcriptionType2
         leftTranscriptionType = transcriptionType;
         rightFolioID = folioID2;
-        rightTranscriptionType = transcriptionType2 || 'tl';
+        rightTranscriptionType = transcriptionType2 || firstTranscriptionType;
       } else {
         // route /ec/:folioID
         // route /ec/:folioID/:transcriptionType
         leftTranscriptionType = 'f';
         rightFolioID = folioID;
-        rightTranscriptionType = transcriptionType || 'tl';
+        rightTranscriptionType = transcriptionType || firstTranscriptionType;
       }
 
       viewports = {

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -247,10 +247,14 @@ class Navigation extends React.Component {
               onClick={this.changeType}
             >
               {Object.keys(this.props.document.transcriptionTypes).map(ttKey => (
-                <MenuItem value={ttKey}>{this.props.document.transcriptionTypes[ttKey]}</MenuItem>
+                <MenuItem value={ttKey} key={ttKey}>{this.props.document.transcriptionTypes[ttKey]}</MenuItem>
               ))}
-              <MenuItem value="f">{DocumentHelper.transcriptionTypeLabels.f}</MenuItem>
-              <MenuItem value="glossary">{DocumentHelper.transcriptionTypeLabels.glossary}</MenuItem>
+              <MenuItem value="f" key="f">
+                {DocumentHelper.transcriptionTypeLabels.f}
+              </MenuItem>
+              <MenuItem value="glossary" key="glossary">
+                {DocumentHelper.transcriptionTypeLabels.glossary}
+              </MenuItem>
             </Select>
             <span
               title="Toggle folio help"

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -14,7 +14,7 @@ const baseConfig = {
 export const Development = () => (
   <EditionCrafter config={{
     ...baseConfig,
-    iiifManifest: 'http://localhost:8080/fr640_3r-3v-example/iiif/manifest.json'
+    iiifManifest: 'http://localhost:8080/fr640_3r-3v-example/iiif/manifest.json',
   }}
   />
 );
@@ -22,7 +22,7 @@ export const Development = () => (
 export const Testing = () => (
   <EditionCrafter config={{
     ...baseConfig,
-    iiifManifest: 'https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json'
+    iiifManifest: 'https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json',
   }}
   />
 );


### PR DESCRIPTION
# Summary

- updates the default viewport settings to use the first transcription type in the `document.transcriptionTypes` array instead of hardcoding it to `tl`
- adds `key` props to the `Navigation` select menu items, addressing a React warning

Closes #50.