### PR TITLE
Truncate image grid captions

### DIFF
--- a/editioncrafter/src/scss/_imageGridView.scss
+++ b/editioncrafter/src/scss/_imageGridView.scss
@@ -33,8 +33,8 @@
 	color: white;
 	margin: 0 10px;
 	white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .hidden {

--- a/editioncrafter/src/scss/_imageGridView.scss
+++ b/editioncrafter/src/scss/_imageGridView.scss
@@ -31,6 +31,10 @@
 .imageGridComponent > ul > li > .thumbnail-caption {
 	text-align: center;
 	color: white;
+	margin: 0 10px;
+	white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .hidden {
@@ -41,7 +45,7 @@
 	.imageGridToolbar {
 		padding: 5px;
 		color: white;
-		
+
 		.jump-to {
 			float: right;
 			display: 'inline';
@@ -56,5 +60,5 @@
 				cursor: pointer;
 			}
 		}
-	}	
+	}
 }

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -14,7 +14,7 @@ const baseConfig = {
 export const Development = () => (
   <EditionCrafter config={{
     ...baseConfig,
-    iiifManifest: 'http://localhost:8080/fr640_3r-3v-example/iiif/manifest.json',
+    iiifManifest: 'http://localhost:8080/FHL_007548705_ISLETA_BAPTISMS_1/iiif/manifest.json',
   }}
   />
 );


### PR DESCRIPTION
# Summary

- uses CSS to add a horizontal margin to the image captions in the gallery view and truncate any overflowed test with an ellipsis

# Screenshots

## Before

<img width="793" alt="Screenshot 2023-08-22 at 11 23 37 AM" src="https://github.com/cu-mkp/editioncrafter/assets/64725469/443b1825-e0fe-43d4-9ca0-157c839819c4">

## After

<img width="776" alt="Screenshot 2023-08-22 at 11 23 07 AM" src="https://github.com/cu-mkp/editioncrafter/assets/64725469/0daa549b-6dfa-42ac-b0df-d8ac2fc0f433">
