### PR TITLE
Fix `TranscriptionView` conflict between React and transcription element `ref` attributes

### DIFF
--- a/editioncrafter/package-lock.json
+++ b/editioncrafter/package-lock.json
@@ -14,7 +14,7 @@
         "@recogito/annotorious-openseadragon": "^2.7.11",
         "axios": "^1.3.4",
         "history": "^5.3.0",
-        "html-react-parser": "^3.0.9",
+        "html-react-parser": "^4.2.2",
         "openseadragon": "^4.1.0",
         "prop-types": "^15.5.10",
         "react-icons": "^4.8.0",
@@ -15729,12 +15729,30 @@
       "dev": true
     },
     "node_modules/html-dom-parser": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-3.1.7.tgz",
-      "integrity": "sha512-cDgNF4YgF6J3H+d9mcldGL19p0GzVdS3iGuDNzYWQpU47q3+IRM85X3Xo07E+nntF4ek4s78A9V24EwxlPTjig==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-4.0.0.tgz",
+      "integrity": "sha512-TUa3wIwi80f5NF8CVWzkopBVqVAtlawUzJoLwVLHns0XSJGynss4jiY0mTWpiDOsuyw+afP+ujjMgRh9CoZcXw==",
       "dependencies": {
         "domhandler": "5.0.3",
-        "htmlparser2": "8.0.2"
+        "htmlparser2": "9.0.0"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/htmlparser2": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.0.0.tgz",
+      "integrity": "sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "node_modules/html-element-map": {
@@ -15815,14 +15833,14 @@
       }
     },
     "node_modules/html-react-parser": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-3.0.16.tgz",
-      "integrity": "sha512-ysQZtRFPcg+McVb4B05oNWSnqM14zagpvTgGcI5e1/BvCl38YwzWzKibrbBmXeemg70olN1bAoeixo7o06G5Eg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-4.2.2.tgz",
+      "integrity": "sha512-lh0wEGISnFZEAmvQqK4xc0duFMUh/m9YYyAhFursWxdtNv+hCZge0kj1y4wep6qPB5Zm33L+2/P6TcGWAJJbjA==",
       "dependencies": {
         "domhandler": "5.0.3",
-        "html-dom-parser": "3.1.7",
+        "html-dom-parser": "4.0.0",
         "react-property": "2.0.0",
-        "style-to-js": "1.1.3"
+        "style-to-js": "1.1.4"
       },
       "peerDependencies": {
         "react": "0.14 || 15 || 16 || 17 || 18"
@@ -15867,6 +15885,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
       "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -30387,17 +30406,17 @@
       }
     },
     "node_modules/style-to-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.3.tgz",
-      "integrity": "sha512-zKI5gN/zb7LS/Vm0eUwjmjrXWw8IMtyA8aPBJZdYiQTXj4+wQ3IucOLIOnF7zCHxvW8UhIGh/uZh/t9zEHXNTQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.4.tgz",
+      "integrity": "sha512-zEeU3vy9xL/hdLBFmzqjhm+2vJ1Y35V0ctDeB2sddsvN1856OdMZUCOOfKUn3nOjjEKr6uLhOnY4CrX6gLDRrA==",
       "dependencies": {
-        "style-to-object": "0.4.1"
+        "style-to-object": "0.4.2"
       }
     },
     "node_modules/style-to-object": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
-      "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.2.tgz",
+      "integrity": "sha512-1JGpfPB3lo42ZX8cuPrheZbfQ6kqPPnPHlKMyeRYtfKD+0jG+QsXgXN57O/dvJlzlB2elI6dGmrPnl5VPQFPaA==",
       "dependencies": {
         "inline-style-parser": "0.1.1"
       }

--- a/editioncrafter/package.json
+++ b/editioncrafter/package.json
@@ -31,7 +31,7 @@
     "@recogito/annotorious-openseadragon": "^2.7.11",
     "axios": "^1.3.4",
     "history": "^5.3.0",
-    "html-react-parser": "^3.0.9",
+    "html-react-parser": "^4.2.2",
     "openseadragon": "^4.1.0",
     "prop-types": "^15.5.10",
     "react-icons": "^4.8.0",

--- a/editioncrafter/src/component/Parser.js
+++ b/editioncrafter/src/component/Parser.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import HtmlReactParser from 'html-react-parser';
+
+// This component addresses a conflict between React and
+// documents whose elements contain `ref` attributes.
+// Because we're parsing transcription contents as React
+// elements, migrating TranscriptionView to a function
+// component caused React to error about the ref attributes.
+
+// The short-term fix is to wrap this simple class component
+// around the parser.
+
+class Parser extends React.Component {
+  render() {
+    const { html, htmlToReactParserOptionsSide } = this.props;
+
+    return HtmlReactParser(html, htmlToReactParserOptionsSide);
+  }
+}
+
+export default Parser;

--- a/editioncrafter/src/component/TranscriptionView.js
+++ b/editioncrafter/src/component/TranscriptionView.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import Parser from 'html-react-parser';
 import { useSearchParams } from 'react-router-dom';
 import Navigation from './Navigation';
 import Pagination from './Pagination';
+import Parser from './Parser';
 import EditorComment from './EditorComment';
 import ErrorBoundary from './ErrorBoundary';
 import Watermark from './Watermark';
@@ -140,7 +140,10 @@ const TranscriptionView = (props) => {
               className="surface grid-mode"
               style={surfaceStyle}
             >
-              {Parser(html, htmlToReactParserOptionsSide)}
+              <Parser
+                html={html}
+                htmlToReactParserOptionsSide={htmlToReactParserOptionsSide}
+              />
             </div>
           </ErrorBoundary>
         </div>


### PR DESCRIPTION
# Summary

This PR fixes a bug that occurred when the TEI data from a transcription included elements with `ref` attributes.

We're using [html-react-parser](https://www.npmjs.com/package/html-react-parser) to parse the transcription, which apparently inserts its DOM tree directly into the parent React component. Now that `TranscriptionView` is a functional component as of #55, React gets confused by the `ref` attributes.

The quick fix, which I hope is short-term until we figure out something nicer, is to create a class component to wrap around `html-react-parser`'s output.

