### PR TITLE
Redesign zone UI

### DIFF
--- a/editioncrafter/src/component/TranscriptionView.js
+++ b/editioncrafter/src/component/TranscriptionView.js
@@ -10,12 +10,11 @@ import Watermark from './Watermark';
 
 const addZoneStyle = (selectedZone, domNode, facses) => {
   if (facses.includes(selectedZone)) {
-    // Keep any inline styles that might already be set
-    const style = 'outline:2px solid #9c9100;';
-    if (domNode.attribs.style) {
-      domNode.attribs.style += style;
+    // Keep any classes that might already be set
+    if (domNode.attribs.classname) {
+      domNode.attribs.classname += ' selected-zone';
     } else {
-      domNode.attribs.style = style;
+      domNode.attribs.classname = 'selected-zone';
     }
   }
 

--- a/editioncrafter/src/scss/_imageView.scss
+++ b/editioncrafter/src/scss/_imageView.scss
@@ -23,8 +23,8 @@
 	fill: rgba(67, 133, 246, 0.1) !important;
 }
 
-.a9s-annotation.a9s-annotation:hover > rect,
-.a9s-annotation.a9s-annotation:hover > polygon
+.a9s-annotation.a9s-annotation.hover > rect,
+.a9s-annotation.a9s-annotation.hover > polygon
  {
 	stroke: #4385F6 !important;
 	stroke-linejoin: round;

--- a/editioncrafter/src/scss/_imageView.scss
+++ b/editioncrafter/src/scss/_imageView.scss
@@ -15,14 +15,17 @@
 		height: 100vh;
 	}
 
-.a9s-annotation > polygon:hover {
-	stroke-opacity: 1 !important;
-	stroke-width: 2 !important;
+.a9s-annotation.a9s-annotation.selected > rect,
+.a9s-annotation.a9s-annotation.selected > polygon
+ {
+	stroke: #4385F6 !important;
+	stroke-linejoin: round;
+	fill: rgba(67, 133, 246, 0.1) !important;
 }
 
-.a9s-annotation.selected > polygon {
-	stroke-opacity: 1 !important;
-	stroke-width: 2 !important;
-	stroke-dasharray: initial !important;
-	stroke: #d4e817 !important;
+.a9s-annotation.a9s-annotation:hover > rect,
+.a9s-annotation.a9s-annotation:hover > polygon
+ {
+	stroke: #4385F6 !important;
+	stroke-linejoin: round;
 }

--- a/editioncrafter/src/scss/_transcriptView.scss
+++ b/editioncrafter/src/scss/_transcriptView.scss
@@ -5,7 +5,7 @@
 	.transcriptContent {
 		padding: 50px 16px;
 		@include md {
-			padding: 5px 16px;
+			padding: 5px 0;
 		}
 
 	  -webkit-user-select: text;
@@ -183,6 +183,11 @@ tei-add {
 	color: blue;
   vertical-align: super;
   font-size: 10pt;
+}
+
+.selected-zone {
+	background: #EAF1FD;
+	border-radius: 5px;
 }
 
 .editor-comment-content {

--- a/editioncrafter/src/scss/_transcriptView.scss
+++ b/editioncrafter/src/scss/_transcriptView.scss
@@ -5,7 +5,7 @@
 	.transcriptContent {
 		padding: 50px 16px;
 		@include md {
-			padding: 5px 0;
+			padding: 5px 16px;
 		}
 
 	  -webkit-user-select: text;


### PR DESCRIPTION
# Summary

- refreshes the colors for selected zones in both the image view and the transcription view
- small refactor to use a `selected-zone` class instead of inline styles for TEI elements whose zone is currently selected (not sure why I went for inline styles originally)

The one divergence from the mockup is that I had to keep the existing horizontal margins in the transcription view. The structure of the HTML elements in the transcription view makes it impossible to display the blue background all the way to the edges while keeping the text margins.

# Screenshot

<img width="1879" alt="Screenshot 2023-09-18 at 4 30 30 PM" src="https://github.com/cu-mkp/editioncrafter/assets/64725469/dec4f4b4-22c4-45dc-99ae-cff7ac20fb38">

(Side note: I was unable to upload a screen recording because it exceeded GitHub's 10 MB file upload limit. Is that limit new?)