### PR TITLE
Fix zoom buttons

### DIFF
--- a/editioncrafter/src/component/ImageView.js
+++ b/editioncrafter/src/component/ImageView.js
@@ -46,6 +46,14 @@ const ImageView = (props) => {
     viewer.viewport.fitVertically();
   };
 
+  const onZoomIn = (e) => {
+    viewer.viewport.zoomBy(2)
+  }
+
+  const onZoomOut = (e) => {
+    viewer.viewport.zoomBy(0.5)
+  }
+
   useEffect(() => {
     if (anno) {
       // Note: The `on` method does NOT overwrite any previous handlers,
@@ -76,15 +84,13 @@ const ImageView = (props) => {
       setViewer(null);
       setAnno(null);
     } else {
-      const in_id = `os-zoom-in ${props.side}`;
-      const out_id = `os-zoom-out ${props.side}`;
-
       const newViewer = OpenSeadragon({
         element: el,
-        zoomInButton: in_id,
-        zoomOutButton: out_id,
         showNavigationControl: false,
-        zoomPerClick: 1,
+        zoomPerClick: 2,
+        gestureSettingsMouse: {
+          clickToZoom: false
+        },
       });
 
       setViewer(newViewer);
@@ -138,6 +144,8 @@ const ImageView = (props) => {
           onZoomFixed_2={onZoomFixed_2}
           onZoomFixed_3={onZoomFixed_3}
           onZoomGrid={onZoomGrid}
+          onZoomIn={onZoomIn}
+          onZoomOut={onZoomOut}
         />
         <SeaDragonComponent
           key={props.folioID}

--- a/editioncrafter/src/component/ImageZoomControl.js
+++ b/editioncrafter/src/component/ImageZoomControl.js
@@ -1,19 +1,19 @@
 import React from 'react';
 
-export default class ImageZoomControl extends React.Component {
-  render() {
-    const in_id = `os-zoom-in ${this.props.side}`;
-    const out_id = `os-zoom-out ${this.props.side}`;
-    const onZoomGrid = (this.props.documentView.bookMode ? null : this.props.onZoomGrid);
-    return (
-      <ul className="ImageZoomControl">
-        <li><i title="Zoom In" id={in_id} className="zoom-in fas fa-plus-circle fa-2x" /></li>
-        <li><i title="Fixed Zoom 1" onClick={this.props.onZoomFixed_1} className="zoom-3 fas fa-circle fa-2x" /></li>
-        <li><i title="Fixed Zoom 2" onClick={this.props.onZoomFixed_2} className="zoom-2 fas fa-circle fa-lg" /></li>
-        <li><i title="Fixed Zoom 3" onClick={this.props.onZoomFixed_3} className="zoom-1 fas fa-circle" /></li>
-        <li><i title="Zoom Out" id={out_id} className="zoom-out fas fa-minus-circle fa-2x" /></li>
-        <li className={this.props.documentView.bookMode ? 'disabled' : ''}><i title="Return to grid mode (not available in book mode)" onClick={onZoomGrid} className="zoom-grid fas fa-th fa-2x" /></li>
-      </ul>
-    );
-  }
+const ImageZoomControl = (props) => {
+  const in_id = `os-zoom-in ${props.side}`;
+  const out_id = `os-zoom-out ${props.side}`;
+  const onZoomGrid = (props.documentView.bookMode ? null : props.onZoomGrid);
+  return (
+    <ul className="ImageZoomControl">
+      <li><i title="Zoom In" id={in_id} onClick={props.onZoomIn} className="zoom-in fas fa-plus-circle fa-2x" /></li>
+      <li><i title="Fixed Zoom 1" onClick={props.onZoomFixed_1} className="zoom-3 fas fa-circle fa-2x" /></li>
+      <li><i title="Fixed Zoom 2" onClick={props.onZoomFixed_2} className="zoom-2 fas fa-circle fa-lg" /></li>
+      <li><i title="Fixed Zoom 3" onClick={props.onZoomFixed_3} className="zoom-1 fas fa-circle" /></li>
+      <li><i title="Zoom Out" id={out_id} onClick={props.onZoomOut} className="zoom-out fas fa-minus-circle fa-2x" /></li>
+      <li className={props.documentView.bookMode ? 'disabled' : ''}><i title="Return to grid mode (not available in book mode)" onClick={onZoomGrid} className="zoom-grid fas fa-th fa-2x" /></li>
+    </ul>
+  );
 }
+
+export default ImageZoomControl;


### PR DESCRIPTION
# Summary

## High Level

Fixes the zoom buttons in the viewer so they correctly zoom in and out.

Also, refactors `ImageZoomControl` to a function component as per #56 (the simplest refactor yet).

## Low Level

I couldn't actually diagnose why they quit working between the previous release and now. The bug had the same symptoms as https://github.com/openseadragon/openseadragon/issues/516, but none of the solutions there worked. My initial guess was that something happened when I turned `ImageView` into a function component that caused the viewer to somehow lose track of the button elements between renders.

Either way, I noticed that the fixed zoom buttons were already programmatically setting zoom, so I created `onZoom` callbacks for the regular zooming and added `onClick` handlers to the buttons.

Also, as mentioned in the linked OSD issue above, I updated out method of preventing zoom-on-click from an option that lowered the zoom rate to 0 to an option that more narrowly disables zoom-on-click.