### PR TITLE
Multidocument config options

### DIFF
--- a/editioncrafter/src/action/DocumentActions.js
+++ b/editioncrafter/src/action/DocumentActions.js
@@ -113,6 +113,18 @@ function parseAnnotationURLs(canvas, transcriptionTypes) {
 const MAX_THUMBNAIL_DIMENSION = 130;
 
 function parseManifest(manifest, transcriptionTypes) {
+  if (manifest.type == 'variorum') {
+    let folios = [];
+    Object.keys(manifest.documentData).forEach((key) => {
+      folios = folios.concat(parseSingleManifest(manifest.documentData[key], transcriptionTypes, key));
+    });
+    return folios;
+  }
+  return parseSingleManifest(manifest, transcriptionTypes);
+}
+
+function parseSingleManifest(manifest, transcriptionTypes, document) {
+
   const folios = [];
 
   // make sure this is a IIIF Presentation API v3 Manifest
@@ -146,6 +158,7 @@ function parseManifest(manifest, transcriptionTypes) {
 
     const folio = {
       id: folioID,
+      doc_id: document || manifest.id,
       name: canvasLabel,
       pageNumber: i,
       image_zoom_url: imageURL,
@@ -158,7 +171,6 @@ function parseManifest(manifest, transcriptionTypes) {
 
     folios.push(folio);
   }
-
   return folios;
 }
 

--- a/editioncrafter/src/action/DocumentActions.js
+++ b/editioncrafter/src/action/DocumentActions.js
@@ -113,7 +113,7 @@ function parseAnnotationURLs(canvas, transcriptionTypes) {
 const MAX_THUMBNAIL_DIMENSION = 130;
 
 function parseManifest(manifest, transcriptionTypes) {
-  if (manifest.type == 'variorum') {
+  if (manifest.type === 'variorum') {
     let folios = [];
     Object.keys(manifest.documentData).forEach((key) => {
       folios = folios.concat(parseSingleManifest(manifest.documentData[key], transcriptionTypes, key));
@@ -124,7 +124,6 @@ function parseManifest(manifest, transcriptionTypes) {
 }
 
 function parseSingleManifest(manifest, transcriptionTypes, document) {
-
   const folios = [];
 
   // make sure this is a IIIF Presentation API v3 Manifest

--- a/editioncrafter/src/action/DocumentActions.js
+++ b/editioncrafter/src/action/DocumentActions.js
@@ -116,7 +116,7 @@ function parseManifest(manifest, transcriptionTypes) {
   if (manifest.type === 'variorum') {
     let folios = [];
     Object.keys(manifest.documentData).forEach((key) => {
-      folios = folios.concat(parseSingleManifest(manifest.documentData[key], transcriptionTypes, key));
+      folios = folios.concat(parseSingleManifest(manifest.documentData[key], transcriptionTypes[key], key));
     });
     return folios;
   }

--- a/editioncrafter/src/action/initialState/documentInitialState.js
+++ b/editioncrafter/src/action/initialState/documentInitialState.js
@@ -1,9 +1,10 @@
-export default function documentInitalState(iiifManifest, documentName, transcriptionTypes, variorum = false) {
+export default function documentInitalState(iiifManifest, documentName, transcriptionTypes, variorum = false, derivativeNames = null) {
   return {
-    documentName: documentName,
+    documentName,
+    derivativeNames,
     manifestURL: iiifManifest,
     transcriptionTypes,
-    variorum: variorum,
+    variorum,
     folios: [],
     loaded: false,
     folioIndex: {},

--- a/editioncrafter/src/action/initialState/documentInitialState.js
+++ b/editioncrafter/src/action/initialState/documentInitialState.js
@@ -1,8 +1,9 @@
-export default function documentInitalState(iiifManifest, documentName, transcriptionTypes) {
+export default function documentInitalState(iiifManifest, documentName, transcriptionTypes, variorum = false) {
   return {
     documentName: documentName,
     manifestURL: iiifManifest,
     transcriptionTypes,
+    variorum: variorum,
     folios: [],
     loaded: false,
     folioIndex: {},

--- a/editioncrafter/src/action/rootReducer.js
+++ b/editioncrafter/src/action/rootReducer.js
@@ -11,11 +11,11 @@ import documentInitialState from './initialState/documentInitialState';
 
 export default function rootReducer(config) {
   const {
-    iiifManifest, documentName, transcriptionTypes,
+    iiifManifest, documentName, transcriptionTypes, variorum = false
   } = config;
   return combineReducers({
     diplomatic: createReducer('DiplomaticActions', DiplomaticActions, diplomaticInitialState),
-    document: createReducer('DocumentActions', DocumentActions, documentInitialState(iiifManifest, documentName, transcriptionTypes)),
+    document: createReducer('DocumentActions', DocumentActions, documentInitialState(iiifManifest, documentName, transcriptionTypes, variorum)),
     glossary: createReducer('GlossaryActions', GlossaryActions, glossaryInitialState()),
   });
 }

--- a/editioncrafter/src/action/rootReducer.js
+++ b/editioncrafter/src/action/rootReducer.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 
+// eslint-disable-next-line import/no-cycle
 import { createReducer } from '../model/ReduxStore';
 import GlossaryActions from './GlossaryActions';
 import DocumentActions from './DocumentActions';
@@ -11,11 +12,24 @@ import documentInitialState from './initialState/documentInitialState';
 
 export default function rootReducer(config) {
   const {
-    iiifManifest, documentName, transcriptionTypes, variorum = false
+    documentName, variorum = false,
   } = config;
+  const transcriptionTypesInfo = {};
+  const manifestInfo = {};
+  const derivativesInfo = {};
+  if (variorum) {
+    Object.keys(config.documentInfo).forEach((key) => {
+      transcriptionTypesInfo[key] = config.documentInfo[key].transcriptionTypes;
+      manifestInfo[key] = config.documentInfo[key].iiifManifest;
+      derivativesInfo[key] = config.documentInfo[key].documentName;
+    });
+  }
+  const transcriptionTypes = variorum ? transcriptionTypesInfo : config.transcriptionTypes;
+  const iiifManifest = variorum ? manifestInfo : config.iiifManifest;
+  const derivativeNames = variorum && derivativesInfo;
   return combineReducers({
     diplomatic: createReducer('DiplomaticActions', DiplomaticActions, diplomaticInitialState),
-    document: createReducer('DocumentActions', DocumentActions, documentInitialState(iiifManifest, documentName, transcriptionTypes, variorum)),
+    document: createReducer('DocumentActions', DocumentActions, documentInitialState(iiifManifest, documentName, transcriptionTypes, variorum, derivativeNames)),
     glossary: createReducer('GlossaryActions', GlossaryActions, glossaryInitialState()),
   });
 }

--- a/editioncrafter/src/component/ImageGridView.js
+++ b/editioncrafter/src/component/ImageGridView.js
@@ -84,8 +84,8 @@ class ImageGridView extends React.Component {
           onClick={this.onSelectDoc}
         >
           <MenuItem value="none" key="none">{this.state.currentDoc ? 'View All' : 'Select a Document'}</MenuItem>
-          { this.props.document.manifestURL.map((doc) => (
-            <MenuItem value={doc} key={doc}>{doc}</MenuItem>
+          { Object.keys(this.props.document.derivativeNames).map((key) => (
+            <MenuItem value={key} key={key}>{this.props.document.derivativeNames[key]}</MenuItem>
           ))}
         </Select>
       </div>
@@ -93,10 +93,8 @@ class ImageGridView extends React.Component {
   }
 
   onSelectDoc = (event) => {
-    console.log('clicked on', event.target.value);
     if (event.target.value !== 'none') {
       this.setState({ ...this.state, currentDoc: event.target.value });
-      console.log('new state', this.state.currentDoc);
     } else {
       this.setState({ ...this.state, currentDoc: null });
     }
@@ -110,7 +108,6 @@ class ImageGridView extends React.Component {
 
   componentDidMount() {
     const { documentView } = this.props;
-    console.log(this.props);
     const folioID = documentView[this.props.side].iiifShortID;
     const thumbs = this.generateThumbs(folioID, this.state.currentDoc ? this.props.document.folios.filter((folio) => (folio.doc_id === this.state.currentDoc)) : this.props.document.folios);
     const thumbCount = (thumbs.length > this.loadIncrement) ? this.loadIncrement : thumbs.length;

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -19,7 +19,6 @@ const initialPopoverObj = {
 };
 
 const Navigation = (props) => {
-  console.log(props);
   const [popover, setPopover] = useState({ ...initialPopoverObj });
   const [openHelp, setOpenHelp] = useState(false);
 

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -19,6 +19,7 @@ const initialPopoverObj = {
 };
 
 const Navigation = (props) => {
+  console.log(props);
   const [popover, setPopover] = useState({ ...initialPopoverObj });
   const [openHelp, setOpenHelp] = useState(false);
 
@@ -248,8 +249,8 @@ const Navigation = (props) => {
             id="doc-type"
             onClick={changeType}
           >
-            {Object.keys(props.document.transcriptionTypes).map(ttKey => (
-              <MenuItem value={ttKey} key={ttKey}>{props.document.transcriptionTypes[ttKey]}</MenuItem>
+            {Object.keys(props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).annotationURLs).map(ttKey => (
+              <MenuItem value={ttKey} key={ttKey}>{props.document.variorum ? props.document.transcriptionTypes[props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).doc_id][ttKey] : props.document.transcriptionTypes[ttKey]}</MenuItem>
             ))}
             <MenuItem value="f" key="f">
               {DocumentHelper.transcriptionTypeLabels.f}

--- a/editioncrafter/src/model/ReduxStore.js
+++ b/editioncrafter/src/model/ReduxStore.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-cycle */
 import { createStore, applyMiddleware } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 import { put } from 'redux-saga/effects';

--- a/editioncrafter/src/saga/RouteListenerSaga.js
+++ b/editioncrafter/src/saga/RouteListenerSaga.js
@@ -1,6 +1,8 @@
+/* eslint-disable prefer-destructuring */
 import axios from 'axios';
 import { takeEvery, select } from 'redux-saga/effects';
 
+// eslint-disable-next-line import/no-cycle
 import { putResolveAction } from '../model/ReduxStore';
 import { loadFolio } from '../model/Folio';
 
@@ -27,27 +29,24 @@ function* userNavigation(action) {
 
 function* resolveDocumentManifest() {
   const document = yield select(justDocument);
-  console.log(document);
   if (!document.loaded) {
     // handle the case where we've passed in an array of manifest URLs, in which case the `variorum` parameter should be set to `true`
     if (document.variorum) {
-      let variorumData = {};
-      for (var url of document.manifestURL) {
+      const variorumData = {};
+      for (const url of document.manifestURL) {
         const response = yield axios.get(url);
         variorumData[response.data.id] = response.data;
-      };
+      }
       const variorumManifest = {
-        type: "variorum",
-        documentData: variorumData
+        type: 'variorum',
+        documentData: variorumData,
       };
       yield putResolveAction('DocumentActions.loadDocument', variorumManifest);
       return variorumManifest;
     }
-    else {
-      const singleResponse = yield axios.get(document.manifestURL);
-      yield putResolveAction('DocumentActions.loadDocument', singleResponse.data);
-      return singleResponse.data;
-    }
+    const singleResponse = yield axios.get(document.manifestURL);
+    yield putResolveAction('DocumentActions.loadDocument', singleResponse.data);
+    return singleResponse.data;
   }
 
   return null;
@@ -81,18 +80,23 @@ function* resolveFolio(pathSegments) {
 
 function* resolveGlossary(manifest) {
   const glossary = yield select(justGlossary);
+  // NOTE: need to figure out how to deal with glossary for multidocument manifests
   if (!glossary.loaded) {
     if (
       !manifest?.seeAlso
       || manifest.seeAlso.length === 0
       || !manifest.seeAlso[0].id
     ) {
-      throw new Error('Missing glossary link in seeAlso array.');
+      if (manifest.type !== 'variorum') {
+        throw new Error('Missing glossary link in seeAlso array.');
+      }
+      yield putResolveAction('GlossaryActions.loadGlossary', {});
     }
-
-    const glossaryURL = manifest.seeAlso[0].id;
-    const response = yield axios.get(glossaryURL);
-    yield putResolveAction('GlossaryActions.loadGlossary', response.data);
+    if (manifest.type !== 'variorum') {
+      const glossaryURL = manifest.seeAlso[0].id;
+      const response = yield axios.get(glossaryURL);
+      yield putResolveAction('GlossaryActions.loadGlossary', response.data);
+    }
   }
 }
 

--- a/editioncrafter/src/saga/RouteListenerSaga.js
+++ b/editioncrafter/src/saga/RouteListenerSaga.js
@@ -33,9 +33,9 @@ function* resolveDocumentManifest() {
     // handle the case where we've passed in an array of manifest URLs, in which case the `variorum` parameter should be set to `true`
     if (document.variorum) {
       const variorumData = {};
-      for (const url of document.manifestURL) {
-        const response = yield axios.get(url);
-        variorumData[response.data.id] = response.data;
+      for (const key of Object.keys(document.manifestURL)) {
+        const response = yield axios.get(document.manifestURL[key]);
+        variorumData[key] = response.data;
       }
       const variorumManifest = {
         type: 'variorum',

--- a/editioncrafter/src/saga/RouteListenerSaga.js
+++ b/editioncrafter/src/saga/RouteListenerSaga.js
@@ -27,10 +27,27 @@ function* userNavigation(action) {
 
 function* resolveDocumentManifest() {
   const document = yield select(justDocument);
+  console.log(document);
   if (!document.loaded) {
-    const response = yield axios.get(document.manifestURL);
-    yield putResolveAction('DocumentActions.loadDocument', response.data);
-    return response.data;
+    // handle the case where we've passed in an array of manifest URLs, in which case the `variorum` parameter should be set to `true`
+    if (document.variorum) {
+      let variorumData = {};
+      for (var url of document.manifestURL) {
+        const response = yield axios.get(url);
+        variorumData[response.data.id] = response.data;
+      };
+      const variorumManifest = {
+        type: "variorum",
+        documentData: variorumData
+      };
+      yield putResolveAction('DocumentActions.loadDocument', variorumManifest);
+      return variorumManifest;
+    }
+    else {
+      const singleResponse = yield axios.get(document.manifestURL);
+      yield putResolveAction('DocumentActions.loadDocument', singleResponse.data);
+      return singleResponse.data;
+    }
   }
 
   return null;

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -64,12 +64,23 @@ export const MultiDocument = () => (
   <EditionCrafter config={{
     documentName: 'FHL_007548733_TAOS_BAPTISMS_BATCH_2 and eng-415-145a',
     variorum: true,
-    transcriptionTypes: {
-      translation: 'Translation',
-      transcription: 'Transcription',
-      'eng-415-145a': 'Transcription'
+    documentInfo: {
+      FHL_007548733_TAOS_BAPTISMS_BATCH_2: {
+        documentName: 'Taos Baptisms Batch 2',
+        transcriptionTypes: {
+          translation: 'Translation',
+          transcription: 'Transcription',
+        },
+        iiifManifest: 'https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json',
+      },
+      eng_415_145a: {
+        documentName: 'Eng 415-145a',
+        transcriptionTypes: {
+          'eng-415-145a': 'Transcription',
+        },
+        iiifManifest: 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json',
+      },
     },
-    iiifManifest: ['https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json', 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json'],
   }}
   />
 );

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -60,6 +60,20 @@ export const IntervistePescatori = () => (
   />
 );
 
+export const MultiDocument = () => (
+  <EditionCrafter config={{
+    documentName: 'FHL_007548733_TAOS_BAPTISMS_BATCH_2 and eng-415-145a',
+    variorum: true,
+    transcriptionTypes: {
+      translation: 'Translation',
+      transcription: 'Transcription',
+      'eng-415-145a': 'Transcription'
+    },
+    iiifManifest: ['https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json', 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json'],
+  }}
+  />
+);
+
 export default {
   title: 'EditionCrafter',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "name": "@cu-mkp/edition-crafter-monorepo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@cu-mkp/edition-crafter-monorepo",
+      "license": "MIT"
+    }
+  }
+}


### PR DESCRIPTION
### In this PR
Adds the option to configure the `EditionCrafter` component to accept multiple documents, by setting the `variorum` prop to true and passing in an object with document IDs as keys as the `documentInfo` object. 

For example, a variorum configuration could look like
```
<EditionCrafter config={{
    documentName: 'FHL_007548733_TAOS_BAPTISMS_BATCH_2 and eng-415-145a',
    variorum: true,
    documentInfo: {
      FHL_007548733_TAOS_BAPTISMS_BATCH_2: {
        documentName: 'Taos Baptisms Batch 2',
        transcriptionTypes: {
          translation: 'Translation',
          transcription: 'Transcription',
        },
        iiifManifest: 'https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json',
      },
      eng_415_145a: {
        documentName: 'Eng 415-145a',
        transcriptionTypes: {
          'eng-415-145a': 'Transcription',
        },
        iiifManifest: 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json',
      },
    },
  }}
  />
```

This results in the following behavior, including the ability to unlock the two panes from each other and view a folio from one document on one side and another document on the other side:
![image](https://github.com/cu-mkp/editioncrafter/assets/110847635/63e755e4-0a53-4165-8d46-012c0082924c)
![image](https://github.com/cu-mkp/editioncrafter/assets/110847635/a8c10808-7347-4cae-a3dd-16df2415852d)
![image](https://github.com/cu-mkp/editioncrafter/assets/110847635/eb25b1ac-f49a-4e4d-af97-617b78306cbe)

### Notes and future work
- There is not a lot of flexibility or intelligent error handling built into the component props at the moment; if you use the wrong key for something, or forget to set `variorum` to true, etc., the viewer will crash.
- More work needs to be done on allowing you to truly decouple the behavior of the two sides; currently even if you are in unlocked mode, going to a new folio on the left side will reset the righthand side to show the text of that folio. Possibly when using the viewer for comparing multiple documents that behavior is not desirable and it should be possible to just operate within each pane of the viewer independently more easily.
- Currently I completely punted on dealing with the glossary; if `variorum` is set to true, then an empty glossary is returned. Presumably each document could come with its own glossary link, so instead of loading the glossary when initializing the grid view, I suppose it should be loaded from the proper manifest once a specific folio is chosen? But implementing that will take another chunk of work.
