### PR TITLE
Configuring with multiple documents

### DIFF
--- a/editioncrafter/src/action/DocumentActions.js
+++ b/editioncrafter/src/action/DocumentActions.js
@@ -113,6 +113,17 @@ function parseAnnotationURLs(canvas, transcriptionTypes) {
 const MAX_THUMBNAIL_DIMENSION = 130;
 
 function parseManifest(manifest, transcriptionTypes) {
+  if (manifest.type === 'variorum') {
+    let folios = [];
+    Object.keys(manifest.documentData).forEach((key) => {
+      folios = folios.concat(parseSingleManifest(manifest.documentData[key], transcriptionTypes[key], key));
+    });
+    return folios;
+  }
+  return parseSingleManifest(manifest, transcriptionTypes);
+}
+
+function parseSingleManifest(manifest, transcriptionTypes, document) {
   const folios = [];
 
   // make sure this is a IIIF Presentation API v3 Manifest
@@ -146,6 +157,7 @@ function parseManifest(manifest, transcriptionTypes) {
 
     const folio = {
       id: folioID,
+      doc_id: document || manifest.id,
       name: canvasLabel,
       pageNumber: i,
       image_zoom_url: imageURL,
@@ -158,7 +170,6 @@ function parseManifest(manifest, transcriptionTypes) {
 
     folios.push(folio);
   }
-
   return folios;
 }
 

--- a/editioncrafter/src/action/initialState/documentInitialState.js
+++ b/editioncrafter/src/action/initialState/documentInitialState.js
@@ -1,8 +1,10 @@
-export default function documentInitalState(iiifManifest, documentName, transcriptionTypes) {
+export default function documentInitalState(iiifManifest, documentName, transcriptionTypes, variorum = false, derivativeNames = null) {
   return {
-    documentName: documentName,
+    documentName,
+    derivativeNames,
     manifestURL: iiifManifest,
     transcriptionTypes,
+    variorum,
     folios: [],
     loaded: false,
     folioIndex: {},

--- a/editioncrafter/src/action/rootReducer.js
+++ b/editioncrafter/src/action/rootReducer.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 
+// eslint-disable-next-line import/no-cycle
 import { createReducer } from '../model/ReduxStore';
 import GlossaryActions from './GlossaryActions';
 import DocumentActions from './DocumentActions';
@@ -11,11 +12,24 @@ import documentInitialState from './initialState/documentInitialState';
 
 export default function rootReducer(config) {
   const {
-    iiifManifest, documentName, transcriptionTypes,
+    documentName, variorum = false,
   } = config;
+  const transcriptionTypesInfo = {};
+  const manifestInfo = {};
+  const derivativesInfo = {};
+  if (variorum) {
+    Object.keys(config.documentInfo).forEach((key) => {
+      transcriptionTypesInfo[key] = config.documentInfo[key].transcriptionTypes;
+      manifestInfo[key] = config.documentInfo[key].iiifManifest;
+      derivativesInfo[key] = config.documentInfo[key].documentName;
+    });
+  }
+  const transcriptionTypes = variorum ? transcriptionTypesInfo : config.transcriptionTypes;
+  const iiifManifest = variorum ? manifestInfo : config.iiifManifest;
+  const derivativeNames = variorum && derivativesInfo;
   return combineReducers({
     diplomatic: createReducer('DiplomaticActions', DiplomaticActions, diplomaticInitialState),
-    document: createReducer('DocumentActions', DocumentActions, documentInitialState(iiifManifest, documentName, transcriptionTypes)),
+    document: createReducer('DocumentActions', DocumentActions, documentInitialState(iiifManifest, documentName, transcriptionTypes, variorum, derivativeNames)),
     glossary: createReducer('GlossaryActions', GlossaryActions, glossaryInitialState()),
   });
 }

--- a/editioncrafter/src/component/DocumentView.js
+++ b/editioncrafter/src/component/DocumentView.js
@@ -19,7 +19,7 @@ const paneDefaults = {
 };
 
 const DocumentView = (props) => {
-  const [linkedMode, setLinkedMode] = useState(true);
+  const [linkedMode, setLinkedMode] = useState(!props.document.variorum);
   const [bookMode, setBookMode] = useState(false);
   const [left, setLeft] = useState(paneDefaults);
   const [right, setRight] = useState(paneDefaults);
@@ -49,7 +49,7 @@ const DocumentView = (props) => {
         },
         right: {
           folioID: '-1',
-          transcriptionType: firstTranscriptionType,
+          transcriptionType: document.variorum ? 'g' : firstTranscriptionType,
         },
       };
     }
@@ -342,12 +342,14 @@ const DocumentView = (props) => {
         />
       );
     } if (viewType === 'ImageGridView') {
+      console.log(props.document);
       return (
         <ImageGridView
           key={key}
           documentView={docView}
           documentViewActions={documentViewActions}
           side={side}
+          selectedDoc={props.document.variorum && Object.keys(props.document.derivativeNames)[side === 'left' ? 0 : 1]}
         />
       );
     } if (viewType === 'GlossaryView') {

--- a/editioncrafter/src/component/DocumentView.js
+++ b/editioncrafter/src/component/DocumentView.js
@@ -118,11 +118,13 @@ const DocumentView = (props) => {
     const versoFolio = document.folioIndex[folioID];
     const { name, pageNumber } = versoFolio;
 
+    const documentFolios = document.variorum ? document.folios.filter((f) => f.doc_id === versoFolio.doc_id) : document.folios;
+
     if (!name.endsWith('v') && name.endsWith('r')) {
-      return [document.folios[pageNumber - 1].id, document.folios[pageNumber].id];
+      return [documentFolios[pageNumber - 1].id, documentFolios[pageNumber].id];
     }
 
-    return [document.folios[pageNumber].id, document.folios[pageNumber + 1].id];
+    return [documentFolios[pageNumber].id, documentFolios[pageNumber + 1].id];
   };
 
   const onWidth = (leftWidth, rightWidth) => {
@@ -182,7 +184,6 @@ const DocumentView = (props) => {
   const changeCurrentFolio = (folioID, side, transcriptionType) => {
     // Lookup prev/next
     const currentViewports = getViewports();
-    console.log(currentViewports);
 
     if (bookMode) {
       const [versoID, rectoID] = findBookFolios(folioID);
@@ -258,7 +259,8 @@ const DocumentView = (props) => {
     }
 
     const shortID = viewport.folioID;
-    const folioCount = doc.folios.length;
+    const documentFolios = doc.variorum ? doc.folios.filter((f) => f.doc_id === doc.folioIndex[shortID].doc_id) : doc.folios;
+    const folioCount = documentFolios.length;
     let nextID = '';
     let prevID = '';
     let current_hasPrev = false;
@@ -270,18 +272,18 @@ const DocumentView = (props) => {
 
       if (current_idx > -1) {
         current_hasNext = (current_idx < (folioCount - 2));
-        nextID = current_hasNext ? doc.folios[current_idx + 2].id : '';
+        nextID = current_hasNext ? documentFolios[current_idx + 2].id : '';
         current_hasPrev = (current_idx > 1 && folioCount > 1);
-        prevID = current_hasPrev ? doc.folios[current_idx - 2].id : '';
+        prevID = current_hasPrev ? documentFolios[current_idx - 2].id : '';
       }
     } else {
       const current_idx = doc.folioIndex[shortID].pageNumber;
       if (current_idx > -1) {
         current_hasNext = (current_idx < (folioCount - 1));
-        nextID = current_hasNext ? doc.folios[current_idx + 1].id : '';
+        nextID = current_hasNext ? documentFolios[current_idx + 1].id : '';
 
         current_hasPrev = (current_idx > 0 && folioCount > 1);
-        prevID = current_hasPrev ? doc.folios[current_idx - 1].id : '';
+        prevID = current_hasPrev ? documentFolios[current_idx - 1].id : '';
       }
     }
 

--- a/editioncrafter/src/component/DocumentView.js
+++ b/editioncrafter/src/component/DocumentView.js
@@ -154,6 +154,7 @@ const DocumentView = (props) => {
   };
 
   const navigateFolios = (folioID, transcriptionType, folioID2, transcriptionType2) => {
+    console.log(folioID, transcriptionType, folioID2, transcriptionType2);
     if (!folioID) {
       // goto grid view
       navigateWithParams('/ec');
@@ -181,6 +182,7 @@ const DocumentView = (props) => {
   const changeCurrentFolio = (folioID, side, transcriptionType) => {
     // Lookup prev/next
     const currentViewports = getViewports();
+    console.log(currentViewports);
 
     if (bookMode) {
       const [versoID, rectoID] = findBookFolios(folioID);
@@ -342,7 +344,6 @@ const DocumentView = (props) => {
         />
       );
     } if (viewType === 'ImageGridView') {
-      console.log(props.document);
       return (
         <ImageGridView
           key={key}

--- a/editioncrafter/src/component/ImageGridView.js
+++ b/editioncrafter/src/component/ImageGridView.js
@@ -85,10 +85,10 @@ class ImageGridView extends React.Component {
           id="doc-filter"
           className="dark"
           style={{ color: 'white' }}
-          value={this.state.currentDoc || 'none'}
+          value={this.state.currentDoc || Object.keys(this.props.document.derivativeNames)[0]}
           onClick={this.onSelectDoc}
         >
-          <MenuItem value="none" key="none">{this.state.currentDoc ? 'View All' : 'Select a Document'}</MenuItem>
+          {/* <MenuItem value="none" key="none">{this.state.currentDoc ? 'View All' : 'Select a Document'}</MenuItem> */}
           { Object.keys(this.props.document.derivativeNames).map((key) => (
             <MenuItem value={key} key={key}>{this.props.document.derivativeNames[key]}</MenuItem>
           ))}

--- a/editioncrafter/src/component/ImageGridView.js
+++ b/editioncrafter/src/component/ImageGridView.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import InfiniteScroll from 'react-infinite-scroller';
+import { MenuItem, Select } from '@material-ui/core';
 
 class ImageGridView extends React.Component {
   constructor(props, context) {
@@ -11,6 +12,7 @@ class ImageGridView extends React.Component {
       jumpToBuffer: '',
       thumbs: '',
       visibleThumbs: [],
+      currentDoc: null,
     };
   }
 
@@ -20,7 +22,7 @@ class ImageGridView extends React.Component {
     const nextFolioID = this.props.documentView[this.props.side].iiifShortID;
 
     if (folioID !== nextFolioID) {
-      const thumbs = this.generateThumbs(nextFolioID, this.props.document.folios);
+      const thumbs = this.generateThumbs(nextFolioID, this.state.currentDoc ? this.props.document.folios.filter((folio) => (folio.doc_id === this.state.currentDoc)) : this.props.document.folios);
       const thumbCount = (thumbs.length > this.loadIncrement) ? this.loadIncrement : thumbs.length;
       const visibleThumbs = thumbs.slice(0, thumbCount);
       this.setState({ thumbs, visibleThumbs });
@@ -51,6 +53,7 @@ class ImageGridView extends React.Component {
   renderToolbar() {
     return (
       <div className="imageGridToolbar">
+        { this.props.document.variorum && this.renderDocSelect() }
         <div className="jump-to">
           <form onSubmit={this.onJumpTo}>
             <span>Jump to: </span>
@@ -69,10 +72,44 @@ class ImageGridView extends React.Component {
     );
   }
 
+  // in the case of a variorum, allow for filtering by document
+  renderDocSelect() {
+    return (
+      <div>
+        <Select
+          id="doc-filter"
+          className="dark"
+          style={{ color: 'white' }}
+          value={this.state.currentDoc || 'none'}
+          onClick={this.onSelectDoc}
+        >
+          <MenuItem value="none" key="none">{this.state.currentDoc ? 'View All' : 'Select a Document'}</MenuItem>
+          { Object.keys(this.props.document.derivativeNames).map((key) => (
+            <MenuItem value={key} key={key}>{this.props.document.derivativeNames[key]}</MenuItem>
+          ))}
+        </Select>
+      </div>
+    );
+  }
+
+  onSelectDoc = (event) => {
+    if (event.target.value !== 'none') {
+      this.setState({ ...this.state, currentDoc: event.target.value });
+    } else {
+      this.setState({ ...this.state, currentDoc: null });
+    }
+    const { documentView } = this.props;
+    const folioID = documentView[this.props.side].iiifShortID;
+    const thumbs = this.generateThumbs(folioID, event.target.value !== 'none' ? this.props.document.folios.filter((folio) => (folio.doc_id === event.target.value)) : this.props.document.folios);
+    const thumbCount = (thumbs.length > this.loadIncrement) ? this.loadIncrement : thumbs.length;
+    const visibleThumbs = thumbs.slice(0, thumbCount);
+    this.setState({ thumbs, visibleThumbs });
+  };
+
   componentDidMount() {
     const { documentView } = this.props;
     const folioID = documentView[this.props.side].iiifShortID;
-    const thumbs = this.generateThumbs(folioID, this.props.document.folios);
+    const thumbs = this.generateThumbs(folioID, this.state.currentDoc ? this.props.document.folios.filter((folio) => (folio.doc_id === this.state.currentDoc)) : this.props.document.folios);
     const thumbCount = (thumbs.length > this.loadIncrement) ? this.loadIncrement : thumbs.length;
     const visibleThumbs = thumbs.slice(0, thumbCount);
     this.setState({ thumbs, visibleThumbs });
@@ -88,6 +125,7 @@ class ImageGridView extends React.Component {
 
   generateThumbs(currentID, folios) {
     const thumbs = folios.map((folio, index) => (
+      // eslint-disable-next-line react/no-array-index-key
       <li key={`thumb-${index}`} className="thumbnail">
         <figure className={(folio.id === currentID) ? 'current' : ''}><a id={folio.id} onClick={this.onClickThumb.bind(this, folio.id)}><img src={folio.image_thumbnail_url} alt={folio.name} /></a></figure>
         <figcaption className={(folio.id === currentID) ? 'thumbnail-caption current' : 'thumbnail-caption'}>

--- a/editioncrafter/src/component/ImageGridView.js
+++ b/editioncrafter/src/component/ImageGridView.js
@@ -12,7 +12,7 @@ class ImageGridView extends React.Component {
       jumpToBuffer: '',
       thumbs: '',
       visibleThumbs: [],
-      currentDoc: null,
+      currentDoc: props.selectedDoc || null,
     };
   }
 
@@ -75,7 +75,7 @@ class ImageGridView extends React.Component {
   // in the case of a variorum, allow for filtering by document
   renderDocSelect() {
     return (
-      <div>
+      <div className='doc-select'>
         <Select
           id="doc-filter"
           className="dark"

--- a/editioncrafter/src/component/ImageGridView.js
+++ b/editioncrafter/src/component/ImageGridView.js
@@ -53,6 +53,7 @@ class ImageGridView extends React.Component {
   renderToolbar() {
     return (
       <div className="imageGridToolbar">
+        <span class="fas fa-th" style={{ paddingLeft: '15px' }} />
         { this.props.document.variorum && this.renderDocSelect() }
         <div className="jump-to">
           <form onSubmit={this.onJumpTo}>
@@ -120,6 +121,7 @@ class ImageGridView extends React.Component {
     this.props.documentViewActions.changeCurrentFolio(
       id,
       this.props.side,
+      'f',
     );
   };
 

--- a/editioncrafter/src/component/ImageGridView.js
+++ b/editioncrafter/src/component/ImageGridView.js
@@ -53,8 +53,12 @@ class ImageGridView extends React.Component {
   renderToolbar() {
     return (
       <div className="imageGridToolbar">
-        <span class="fas fa-th" style={{ paddingLeft: '15px' }} />
-        { this.props.document.variorum && this.renderDocSelect() }
+        <span className="fas fa-th" style={{ paddingLeft: '15px' }} />
+        { this.props.document.variorum ? this.renderDocSelect() : (
+          <div className="doc-select" style={{ marginTop: '5px' }}>
+            { this.props.document.documentName }
+          </div>
+        ) }
         <div className="jump-to">
           <form onSubmit={this.onJumpTo}>
             <span>Jump to: </span>

--- a/editioncrafter/src/component/ImageView.js
+++ b/editioncrafter/src/component/ImageView.js
@@ -136,6 +136,7 @@ const ImageView = (props) => {
           side={props.side}
           documentView={props.documentView}
           documentViewActions={props.documentViewActions}
+          documentName={props.document.variorum && props.document.folioIndex[props.folioID].doc_id}
         />
         <ImageZoomControl
           side={props.side}

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -176,6 +176,14 @@ const Navigation = (props) => {
         { documentView[side].transcriptionType !== 'glossary' ? (
 
           <div id="tool-bar-buttons" className="breadcrumbs" style={showButtonsStyle}>
+              
+            <span 
+              class="fas fa-th" 
+              style={{ cursor: documentView[side].transcriptionType !== 'g' ? 'pointer' : 'default', padding: '0 15px' }} 
+              title={documentView[side].transcriptionType !== 'g' && "Return to Grid View"} 
+              onClick={documentView[side].transcriptionType !== 'g' && onGoToGrid} 
+            />
+
             <span
               title="Toggle coordination of views"
               onClick={toggleLockmode}
@@ -197,9 +205,6 @@ const Navigation = (props) => {
             {/* <span title="Toggle single column mode"  onClick={this.toggleColumns}
                                                     className={columnIconClass}></span> */}
                                               &nbsp;
-            { documentView[side].transcriptionType !== 'g' && (
-              <span class="fas fa-th" style={{ cursor: 'pointer', paddingRight: '15px' }} title="Return to Grid View" onClick={onGoToGrid} />
-            )}
             
             <span
               title="Go back"

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -36,6 +36,10 @@ const Navigation = (props) => {
     );
   };
 
+  const onGoToGrid = (event) => {
+    props.documentViewActions.changeTranscriptionType(props.side, 'g');
+  }
+
   const toggleHelp = (event) => {
     setOpenHelp(!openHelp);
   };
@@ -193,6 +197,10 @@ const Navigation = (props) => {
             {/* <span title="Toggle single column mode"  onClick={this.toggleColumns}
                                                     className={columnIconClass}></span> */}
                                               &nbsp;
+            { documentView[side].transcriptionType !== 'g' && (
+              <span class="fas fa-th" style={{ cursor: 'pointer', paddingRight: '15px' }} title="Return to Grid View" onClick={onGoToGrid} />
+            )}
+            
             <span
               title="Go back"
               onClick={changeCurrentFolio}

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -22,6 +22,8 @@ const Navigation = (props) => {
   const [popover, setPopover] = useState({ ...initialPopoverObj });
   const [openHelp, setOpenHelp] = useState(false);
 
+  console.log(props.documentName);
+
   const helpRef = useRef(null);
 
   const onJumpBoxBlur = (event) => {
@@ -228,7 +230,7 @@ const Navigation = (props) => {
               <FaArrowCircleRight />
             </span>
                                               &nbsp;&nbsp;
-            {document.documentName}
+            {props.documentName || document.documentName}
             {' / '}
             <div
               onClick={revealJumpBox}

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -248,8 +248,8 @@ const Navigation = (props) => {
             id="doc-type"
             onClick={changeType}
           >
-            {Object.keys(props.document.transcriptionTypes).map(ttKey => (
-              <MenuItem value={ttKey} key={ttKey}>{props.document.transcriptionTypes[ttKey]}</MenuItem>
+            {Object.keys(props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).annotationURLs).map(ttKey => (
+              <MenuItem value={ttKey} key={ttKey}>{props.document.variorum ? props.document.transcriptionTypes[props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).doc_id][ttKey] : props.document.transcriptionTypes[ttKey]}</MenuItem>
             ))}
             <MenuItem value="f" key="f">
               {DocumentHelper.transcriptionTypeLabels.f}

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -178,7 +178,7 @@ const Navigation = (props) => {
           <div id="tool-bar-buttons" className="breadcrumbs" style={showButtonsStyle}>
               
             <span 
-              class="fas fa-th" 
+              className="fas fa-th" 
               style={{ cursor: documentView[side].transcriptionType !== 'g' ? 'pointer' : 'default', padding: '0 15px' }} 
               title={documentView[side].transcriptionType !== 'g' && "Return to Grid View"} 
               onClick={documentView[side].transcriptionType !== 'g' && onGoToGrid} 

--- a/editioncrafter/src/component/TranscriptionView.js
+++ b/editioncrafter/src/component/TranscriptionView.js
@@ -147,6 +147,7 @@ const TranscriptionView = (props) => {
         side={side}
         documentView={documentView}
         documentViewActions={documentViewActions}
+        documentName={document.variorum && folio.doc_id}
       />
       <Pagination side={side} documentView={documentView} documentViewActions={documentViewActions} />
       <div className="transcriptionViewComponent">

--- a/editioncrafter/src/component/XMLView.js
+++ b/editioncrafter/src/component/XMLView.js
@@ -41,7 +41,7 @@ class XMLView extends Component {
 
     return (
       <div id={thisID} className={thisClass}>
-        <Navigation side={side} documentView={documentView} documentViewActions={documentViewActions} />
+        <Navigation side={side} documentView={documentView} documentViewActions={documentViewActions} documentName={document.variorum && folio.doc_id}/>
         <Pagination side={side} className="pagination_upper" documentView={documentView} documentViewActions={documentViewActions} />
 
         <div className="xmlContentInner">

--- a/editioncrafter/src/model/ReduxStore.js
+++ b/editioncrafter/src/model/ReduxStore.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-cycle */
 import { createStore, applyMiddleware } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 import { put } from 'redux-saga/effects';

--- a/editioncrafter/src/scss/_imageGridView.scss
+++ b/editioncrafter/src/scss/_imageGridView.scss
@@ -59,5 +59,15 @@
 				cursor: pointer;
 			}
 		}
+
+		.doc-select {
+			display: inline;
+			margin-left: 30px;
+			font-size: 0.8rem;
+
+			.MuiInputBase-root {
+				font-size: 0.8rem;
+			}
+		}
 	}
 }

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -60,6 +60,31 @@ export const IntervistePescatori = () => (
   />
 );
 
+export const MultiDocument = () => (
+  <EditionCrafter config={{
+    documentName: 'FHL_007548733_TAOS_BAPTISMS_BATCH_2 and eng-415-145a',
+    variorum: true,
+    documentInfo: {
+      FHL_007548733_TAOS_BAPTISMS_BATCH_2: {
+        documentName: 'Taos Baptisms Batch 2',
+        transcriptionTypes: {
+          translation: 'Translation',
+          transcription: 'Transcription',
+        },
+        iiifManifest: 'https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json',
+      },
+      eng_415_145a: {
+        documentName: 'Eng 415-145a',
+        transcriptionTypes: {
+          'eng-415-145a': 'Transcription',
+        },
+        iiifManifest: 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json',
+      },
+    },
+  }}
+  />
+);
+
 export default {
   title: 'EditionCrafter',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "name": "@cu-mkp/edition-crafter-monorepo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@cu-mkp/edition-crafter-monorepo",
+      "license": "MIT"
+    }
+  }
+}


### PR DESCRIPTION
### In this PR
Adds the option to configure the `EditionCrafter` component to accept multiple documents, by setting the `variorum` prop to true and passing in an object with document IDs as keys as the `documentInfo` object. 

For example, a variorum configuration could look like
```
<EditionCrafter config={{
    documentName: 'FHL_007548733_TAOS_BAPTISMS_BATCH_2 and eng-415-145a',
    variorum: true,
    documentInfo: {
      FHL_007548733_TAOS_BAPTISMS_BATCH_2: {
        documentName: 'Taos Baptisms Batch 2',
        transcriptionTypes: {
          translation: 'Translation',
          transcription: 'Transcription',
        },
        iiifManifest: 'https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json',
      },
      eng_415_145a: {
        documentName: 'Eng 415-145a',
        transcriptionTypes: {
          'eng-415-145a': 'Transcription',
        },
        iiifManifest: 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json',
      },
    },
  }}
  />
```

This results in the following behavior, including the ability to unlock the two panes from each other and view a folio from one document on one side and another document on the other side:
![image](https://github.com/cu-mkp/editioncrafter/assets/110847635/63e755e4-0a53-4165-8d46-012c0082924c)
![image](https://github.com/cu-mkp/editioncrafter/assets/110847635/a8c10808-7347-4cae-a3dd-16df2415852d)
![image](https://github.com/cu-mkp/editioncrafter/assets/110847635/eb25b1ac-f49a-4e4d-af97-617b78306cbe)

### Notes and future work
- There is not a lot of flexibility or intelligent error handling built into the component props at the moment; if you use the wrong key for something, or forget to set `variorum` to true, etc., the viewer will crash.
- More work needs to be done on allowing you to truly decouple the behavior of the two sides; currently even if you are in unlocked mode, going to a new folio on the left side will reset the righthand side to show the text of that folio. Possibly when using the viewer for comparing multiple documents that behavior is not desirable and it should be possible to just operate within each pane of the viewer independently more easily.
- Currently I completely punted on dealing with the glossary; if `variorum` is set to true, then an empty glossary is returned. Presumably each document could come with its own glossary link, so instead of loading the glossary when initializing the grid view, I suppose it should be loaded from the proper manifest once a specific folio is chosen? But implementing that will take another chunk of work.
