### PR TITLE
Reconfigure component props to be destructured

### DIFF
--- a/editioncrafter-umd/src/EditionCrafter.js
+++ b/editioncrafter-umd/src/EditionCrafter.js
@@ -14,10 +14,14 @@ class EditionCrafter {
     if (config.id) {
       this.container = document.getElementById(config.id);
       config.id && ReactDOM.render(
-        <EditionCrafterComponent config={config} />,
+        <EditionCrafterComponent 
+          config={config} //not needed once react component is updated to have destructured props
+          {...config}  
+        />,
         this.container,
       );
     }
+    // note: once the EC react component is updated, 
   }
 
   /**

--- a/editioncrafter/src/index.js
+++ b/editioncrafter/src/index.js
@@ -21,7 +21,7 @@ const EditionCrafter = (props) => {
 
   return (
     <ThemeProvider theme={theme}>
-      <DiploMatic config={props.config} store={createReduxStore(props.config)} />
+      <DiploMatic config={props} store={createReduxStore(props)} />
     </ThemeProvider>
   );
 };

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -1,70 +1,69 @@
 import React from 'react';
 import EditionCrafter from '../src/index';
 
-export const BowInTheCloud = () => (
-  <EditionCrafter config={{
-    documentName: 'eng-415-145a',
-    transcriptionTypes: {
-      'eng-415-145a': 'Transcription'
-    },
-    iiifManifest: 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json',
-  }}
-  />
-);
+// export const BowInTheCloud = () => (
+//   <EditionCrafter config={{
+//     documentName: 'eng-415-145a',
+//     transcriptionTypes: {
+//       'eng-415-145a': 'Transcription'
+//     },
+//     iiifManifest: 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json',
+//   }}
+//   />
+// );
 
-export const DyngleyFamily = () => (
-  <EditionCrafter config={{
-    documentName: 'O.8.35',
-    transcriptionTypes: {
-      transcription: 'Translation',
-    },
-    iiifManifest: 'https://cu-mkp.github.io/dyngleyfamily-editioncrafter-data/O_8_35/iiif/manifest.json',
-  }}
-  />
-);
+// export const DyngleyFamily = () => (
+//   <EditionCrafter config={{
+//     documentName: 'O.8.35',
+//     transcriptionTypes: {
+//       transcription: 'Translation',
+//     },
+//     iiifManifest: 'https://cu-mkp.github.io/dyngleyfamily-editioncrafter-data/O_8_35/iiif/manifest.json',
+//   }}
+//   />
+// );
 
-export const NativeBoundUnbound = () => (
-  <EditionCrafter config={{
-    documentName: 'FHL_007548733_TAOS_BAPTISMS_BATCH_2',
-    transcriptionTypes: {
-      translation: 'Translation',
-      transcription: 'Transcription',
-    },
-    iiifManifest: 'https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json',
-  }}
-  />
-);
+// export const NativeBoundUnbound = () => (
+//   <EditionCrafter config={{
+//     documentName: 'FHL_007548733_TAOS_BAPTISMS_BATCH_2',
+//     transcriptionTypes: {
+//       translation: 'Translation',
+//       transcription: 'Transcription',
+//     },
+//     iiifManifest: 'https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json',
+//   }}
+//   />
+// );
 
-export const BnFMsFr640 = () => (
-  <EditionCrafter config={{
-    documentName: 'BnF Ms. Fr. 640',
-    transcriptionTypes: {
-      tc: 'Diplomatic (FR)',
-      tcn: 'Normalized (FR)',
-      tl: 'Translation (EN)',
-      test: 'Test Field (EN)',
-    },
-    iiifManifest: 'https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json',
-  }}
-  />
-);
+// export const BnFMsFr640 = () => (
+//   <EditionCrafter config={{
+//     documentName: 'BnF Ms. Fr. 640',
+//     transcriptionTypes: {
+//       tc: 'Diplomatic (FR)',
+//       tcn: 'Normalized (FR)',
+//       tl: 'Translation (EN)',
+//       test: 'Test Field (EN)',
+//     },
+//     iiifManifest: 'https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json',
+//   }}
+//   />
+// );
 
 export const IntervistePescatori = () => (
-  <EditionCrafter config={{
-    documentName: 'Interviste Pescatori 1r-35v',
-    transcriptionTypes: {
+  <EditionCrafter
+    documentName='Interviste Pescatori 1r-35v'
+    transcriptionTypes={{
       transcription: 'Transcription'
-    },
-    iiifManifest: 'https://cu-mkp.github.io/venice-editioncrafter-data/data/interviste-pescatori_1r-35v/iiif/manifest.json',
-  }}
+    }}
+    iiifManifest='https://cu-mkp.github.io/venice-editioncrafter-data/data/interviste-pescatori_1r-35v/iiif/manifest.json'
   />
 );
 
 export const MultiDocument = () => (
-  <EditionCrafter config={{
-    documentName: 'FHL_007548733_TAOS_BAPTISMS_BATCH_2 and eng-415-145a',
-    variorum: true,
-    documentInfo: {
+  <EditionCrafter
+    documentName='FHL_007548733_TAOS_BAPTISMS_BATCH_2 and eng-415-145a'
+    variorum
+    documentInfo={{
       FHL_007548733_TAOS_BAPTISMS_BATCH_2: {
         documentName: 'Taos Baptisms Batch 2',
         transcriptionTypes: {
@@ -80,8 +79,7 @@ export const MultiDocument = () => (
         },
         iiifManifest: 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json',
       },
-    },
-  }}
+    }}
   />
 );
 


### PR DESCRIPTION
### In this PR

This PR updates how props are passed to the `EditionCrafter` react component, so that data is passed in as top-level props rather than bundled into one `config` object which is then passed as a single prop.

