### PR TITLE
Ely Green variorum features

### DIFF
--- a/editioncrafter-umd/src/EditionCrafter.js
+++ b/editioncrafter-umd/src/EditionCrafter.js
@@ -14,10 +14,14 @@ class EditionCrafter {
     if (config.id) {
       this.container = document.getElementById(config.id);
       config.id && ReactDOM.render(
-        <EditionCrafterComponent config={config} />,
+        <EditionCrafterComponent 
+          config={config} //not needed once react component is updated to have destructured props
+          {...config}  
+        />,
         this.container,
       );
     }
+    // note: once the EC react component is updated, 
   }
 
   /**

--- a/editioncrafter-umd/src/EditionCrafter.js
+++ b/editioncrafter-umd/src/EditionCrafter.js
@@ -15,7 +15,6 @@ class EditionCrafter {
       this.container = document.getElementById(config.id);
       config.id && ReactDOM.render(
         <EditionCrafterComponent 
-          config={config} //not needed once react component is updated to have destructured props
           {...config}  
         />,
         this.container,

--- a/editioncrafter/src/action/DocumentActions.js
+++ b/editioncrafter/src/action/DocumentActions.js
@@ -113,6 +113,17 @@ function parseAnnotationURLs(canvas, transcriptionTypes) {
 const MAX_THUMBNAIL_DIMENSION = 130;
 
 function parseManifest(manifest, transcriptionTypes) {
+  if (manifest.type === 'variorum') {
+    let folios = [];
+    Object.keys(manifest.documentData).forEach((key) => {
+      folios = folios.concat(parseSingleManifest(manifest.documentData[key], transcriptionTypes[key], key));
+    });
+    return folios;
+  }
+  return parseSingleManifest(manifest, transcriptionTypes);
+}
+
+function parseSingleManifest(manifest, transcriptionTypes, document) {
   const folios = [];
 
   // make sure this is a IIIF Presentation API v3 Manifest
@@ -146,6 +157,7 @@ function parseManifest(manifest, transcriptionTypes) {
 
     const folio = {
       id: folioID,
+      doc_id: document || manifest.id,
       name: canvasLabel,
       pageNumber: i,
       image_zoom_url: imageURL,
@@ -158,7 +170,6 @@ function parseManifest(manifest, transcriptionTypes) {
 
     folios.push(folio);
   }
-
   return folios;
 }
 

--- a/editioncrafter/src/action/initialState/documentInitialState.js
+++ b/editioncrafter/src/action/initialState/documentInitialState.js
@@ -1,10 +1,11 @@
-export default function documentInitalState(iiifManifest, documentName, transcriptionTypes, variorum = false, derivativeNames = null) {
+export default function documentInitalState(iiifManifest, documentName, transcriptionTypes, variorum = false, derivativeNames = null, threePanel = false) {
   return {
     documentName,
     derivativeNames,
     manifestURL: iiifManifest,
     transcriptionTypes,
     variorum,
+    threePanel,
     folios: [],
     loaded: false,
     folioIndex: {},

--- a/editioncrafter/src/action/initialState/documentInitialState.js
+++ b/editioncrafter/src/action/initialState/documentInitialState.js
@@ -1,8 +1,10 @@
-export default function documentInitalState(iiifManifest, documentName, transcriptionTypes) {
+export default function documentInitalState(iiifManifest, documentName, transcriptionTypes, variorum = false, derivativeNames = null) {
   return {
-    documentName: documentName,
+    documentName,
+    derivativeNames,
     manifestURL: iiifManifest,
     transcriptionTypes,
+    variorum,
     folios: [],
     loaded: false,
     folioIndex: {},

--- a/editioncrafter/src/action/rootReducer.js
+++ b/editioncrafter/src/action/rootReducer.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 
+// eslint-disable-next-line import/no-cycle
 import { createReducer } from '../model/ReduxStore';
 import GlossaryActions from './GlossaryActions';
 import DocumentActions from './DocumentActions';
@@ -11,11 +12,24 @@ import documentInitialState from './initialState/documentInitialState';
 
 export default function rootReducer(config) {
   const {
-    iiifManifest, documentName, transcriptionTypes,
+    documentName, variorum = false,
   } = config;
+  const transcriptionTypesInfo = {};
+  const manifestInfo = {};
+  const derivativesInfo = {};
+  if (variorum) {
+    Object.keys(config.documentInfo).forEach((key) => {
+      transcriptionTypesInfo[key] = config.documentInfo[key].transcriptionTypes;
+      manifestInfo[key] = config.documentInfo[key].iiifManifest;
+      derivativesInfo[key] = config.documentInfo[key].documentName;
+    });
+  }
+  const transcriptionTypes = variorum ? transcriptionTypesInfo : config.transcriptionTypes;
+  const iiifManifest = variorum ? manifestInfo : config.iiifManifest;
+  const derivativeNames = variorum && derivativesInfo;
   return combineReducers({
     diplomatic: createReducer('DiplomaticActions', DiplomaticActions, diplomaticInitialState),
-    document: createReducer('DocumentActions', DocumentActions, documentInitialState(iiifManifest, documentName, transcriptionTypes)),
+    document: createReducer('DocumentActions', DocumentActions, documentInitialState(iiifManifest, documentName, transcriptionTypes, variorum, derivativeNames)),
     glossary: createReducer('GlossaryActions', GlossaryActions, glossaryInitialState()),
   });
 }

--- a/editioncrafter/src/action/rootReducer.js
+++ b/editioncrafter/src/action/rootReducer.js
@@ -12,8 +12,9 @@ import documentInitialState from './initialState/documentInitialState';
 
 export default function rootReducer(config) {
   const {
-    documentName, variorum = false,
+    documentName, documentInfo, threePanel = false
   } = config;
+  const variorum = documentInfo && Object.keys(documentInfo).length > 1;
   const transcriptionTypesInfo = {};
   const manifestInfo = {};
   const derivativesInfo = {};
@@ -29,7 +30,7 @@ export default function rootReducer(config) {
   const derivativeNames = variorum && derivativesInfo;
   return combineReducers({
     diplomatic: createReducer('DiplomaticActions', DiplomaticActions, diplomaticInitialState),
-    document: createReducer('DocumentActions', DocumentActions, documentInitialState(iiifManifest, documentName, transcriptionTypes, variorum, derivativeNames)),
+    document: createReducer('DocumentActions', DocumentActions, documentInitialState(iiifManifest, documentName, transcriptionTypes, variorum, derivativeNames, threePanel)),
     glossary: createReducer('GlossaryActions', GlossaryActions, glossaryInitialState()),
   });
 }

--- a/editioncrafter/src/component/DiploMatic.js
+++ b/editioncrafter/src/component/DiploMatic.js
@@ -27,6 +27,7 @@ const DiploMatic = (props) => {
           <RouteListener />
           <div id="content">
             <Routes>
+              <Route path="/ec/:folioID/:transcriptionType/:folioID2/:transcriptionType2/:folioID3/:transcriptionType3" element={<DocumentView {...props} />} exact />
               <Route path="/ec/:folioID/:transcriptionType/:folioID2/:transcriptionType2" element={<DocumentView {...props} />} exact />
               <Route path="/ec/:folioID/:transcriptionType" element={<DocumentView {...props} />} exact />
               <Route path="/ec/:folioID" element={<DocumentView {...props} />} exact />

--- a/editioncrafter/src/component/DocumentView.js
+++ b/editioncrafter/src/component/DocumentView.js
@@ -480,6 +480,7 @@ const DocumentView = (props) => {
           rightPane={renderPane('right', docView)}
           thirdPane={renderPane('third', docView)}
           onWidth={onWidth}
+          threePanel={props.document.threePanel}
         />
       </div>
     );

--- a/editioncrafter/src/component/DocumentView.js
+++ b/editioncrafter/src/component/DocumentView.js
@@ -19,7 +19,7 @@ const paneDefaults = {
 };
 
 const DocumentView = (props) => {
-  const [linkedMode, setLinkedMode] = useState(true);
+  const [linkedMode, setLinkedMode] = useState(!props.document.variorum);
   const [bookMode, setBookMode] = useState(false);
   const [left, setLeft] = useState(paneDefaults);
   const [right, setRight] = useState(paneDefaults);
@@ -49,7 +49,7 @@ const DocumentView = (props) => {
         },
         right: {
           folioID: '-1',
-          transcriptionType: firstTranscriptionType,
+          transcriptionType: document.variorum ? 'g' : firstTranscriptionType,
         },
       };
     }
@@ -118,11 +118,13 @@ const DocumentView = (props) => {
     const versoFolio = document.folioIndex[folioID];
     const { name, pageNumber } = versoFolio;
 
+    const documentFolios = document.variorum ? document.folios.filter((f) => f.doc_id === versoFolio.doc_id) : document.folios;
+
     if (!name.endsWith('v') && name.endsWith('r')) {
-      return [document.folios[pageNumber - 1].id, document.folios[pageNumber].id];
+      return [documentFolios[pageNumber - 1].id, documentFolios[pageNumber].id];
     }
 
-    return [document.folios[pageNumber].id, document.folios[pageNumber + 1].id];
+    return [documentFolios[pageNumber].id, documentFolios[pageNumber + 1].id];
   };
 
   const onWidth = (leftWidth, rightWidth) => {
@@ -154,6 +156,7 @@ const DocumentView = (props) => {
   };
 
   const navigateFolios = (folioID, transcriptionType, folioID2, transcriptionType2) => {
+    console.log(folioID, transcriptionType, folioID2, transcriptionType2);
     if (!folioID) {
       // goto grid view
       navigateWithParams('/ec');
@@ -256,7 +259,8 @@ const DocumentView = (props) => {
     }
 
     const shortID = viewport.folioID;
-    const folioCount = doc.folios.length;
+    const documentFolios = doc.variorum ? doc.folios.filter((f) => f.doc_id === doc.folioIndex[shortID].doc_id) : doc.folios;
+    const folioCount = documentFolios.length;
     let nextID = '';
     let prevID = '';
     let current_hasPrev = false;
@@ -268,18 +272,18 @@ const DocumentView = (props) => {
 
       if (current_idx > -1) {
         current_hasNext = (current_idx < (folioCount - 2));
-        nextID = current_hasNext ? doc.folios[current_idx + 2].id : '';
+        nextID = current_hasNext ? documentFolios[current_idx + 2].id : '';
         current_hasPrev = (current_idx > 1 && folioCount > 1);
-        prevID = current_hasPrev ? doc.folios[current_idx - 2].id : '';
+        prevID = current_hasPrev ? documentFolios[current_idx - 2].id : '';
       }
     } else {
       const current_idx = doc.folioIndex[shortID].pageNumber;
       if (current_idx > -1) {
         current_hasNext = (current_idx < (folioCount - 1));
-        nextID = current_hasNext ? doc.folios[current_idx + 1].id : '';
+        nextID = current_hasNext ? documentFolios[current_idx + 1].id : '';
 
         current_hasPrev = (current_idx > 0 && folioCount > 1);
-        prevID = current_hasPrev ? doc.folios[current_idx - 1].id : '';
+        prevID = current_hasPrev ? documentFolios[current_idx - 1].id : '';
       }
     }
 
@@ -348,6 +352,7 @@ const DocumentView = (props) => {
           documentView={docView}
           documentViewActions={documentViewActions}
           side={side}
+          selectedDoc={props.document.variorum && Object.keys(props.document.derivativeNames)[side === 'left' ? 0 : 1]}
         />
       );
     } if (viewType === 'GlossaryView') {

--- a/editioncrafter/src/component/ImageGridView.js
+++ b/editioncrafter/src/component/ImageGridView.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import InfiniteScroll from 'react-infinite-scroller';
+import { MenuItem, Select } from '@material-ui/core';
 
 class ImageGridView extends React.Component {
   constructor(props, context) {
@@ -11,6 +12,7 @@ class ImageGridView extends React.Component {
       jumpToBuffer: '',
       thumbs: '',
       visibleThumbs: [],
+      currentDoc: props.selectedDoc || null,
     };
   }
 
@@ -20,7 +22,7 @@ class ImageGridView extends React.Component {
     const nextFolioID = this.props.documentView[this.props.side].iiifShortID;
 
     if (folioID !== nextFolioID) {
-      const thumbs = this.generateThumbs(nextFolioID, this.props.document.folios);
+      const thumbs = this.generateThumbs(nextFolioID, this.state.currentDoc ? this.props.document.folios.filter((folio) => (folio.doc_id === this.state.currentDoc)) : this.props.document.folios);
       const thumbCount = (thumbs.length > this.loadIncrement) ? this.loadIncrement : thumbs.length;
       const visibleThumbs = thumbs.slice(0, thumbCount);
       this.setState({ thumbs, visibleThumbs });
@@ -51,6 +53,12 @@ class ImageGridView extends React.Component {
   renderToolbar() {
     return (
       <div className="imageGridToolbar">
+        <span className="fas fa-th" style={{ paddingLeft: '15px' }} />
+        { this.props.document.variorum ? this.renderDocSelect() : (
+          <div className="doc-select" style={{ marginTop: '5px' }}>
+            { this.props.document.documentName }
+          </div>
+        ) }
         <div className="jump-to">
           <form onSubmit={this.onJumpTo}>
             <span>Jump to: </span>
@@ -69,10 +77,44 @@ class ImageGridView extends React.Component {
     );
   }
 
+  // in the case of a variorum, allow for filtering by document
+  renderDocSelect() {
+    return (
+      <div className='doc-select'>
+        <Select
+          id="doc-filter"
+          className="dark"
+          style={{ color: 'white' }}
+          value={this.state.currentDoc || Object.keys(this.props.document.derivativeNames)[0]}
+          onClick={this.onSelectDoc}
+        >
+          {/* <MenuItem value="none" key="none">{this.state.currentDoc ? 'View All' : 'Select a Document'}</MenuItem> */}
+          { Object.keys(this.props.document.derivativeNames).map((key) => (
+            <MenuItem value={key} key={key}>{this.props.document.derivativeNames[key]}</MenuItem>
+          ))}
+        </Select>
+      </div>
+    );
+  }
+
+  onSelectDoc = (event) => {
+    if (event.target.value !== 'none') {
+      this.setState({ ...this.state, currentDoc: event.target.value });
+    } else {
+      this.setState({ ...this.state, currentDoc: null });
+    }
+    const { documentView } = this.props;
+    const folioID = documentView[this.props.side].iiifShortID;
+    const thumbs = this.generateThumbs(folioID, event.target.value !== 'none' ? this.props.document.folios.filter((folio) => (folio.doc_id === event.target.value)) : this.props.document.folios);
+    const thumbCount = (thumbs.length > this.loadIncrement) ? this.loadIncrement : thumbs.length;
+    const visibleThumbs = thumbs.slice(0, thumbCount);
+    this.setState({ thumbs, visibleThumbs });
+  };
+
   componentDidMount() {
     const { documentView } = this.props;
     const folioID = documentView[this.props.side].iiifShortID;
-    const thumbs = this.generateThumbs(folioID, this.props.document.folios);
+    const thumbs = this.generateThumbs(folioID, this.state.currentDoc ? this.props.document.folios.filter((folio) => (folio.doc_id === this.state.currentDoc)) : this.props.document.folios);
     const thumbCount = (thumbs.length > this.loadIncrement) ? this.loadIncrement : thumbs.length;
     const visibleThumbs = thumbs.slice(0, thumbCount);
     this.setState({ thumbs, visibleThumbs });
@@ -83,11 +125,13 @@ class ImageGridView extends React.Component {
     this.props.documentViewActions.changeCurrentFolio(
       id,
       this.props.side,
+      'f',
     );
   };
 
   generateThumbs(currentID, folios) {
     const thumbs = folios.map((folio, index) => (
+      // eslint-disable-next-line react/no-array-index-key
       <li key={`thumb-${index}`} className="thumbnail">
         <figure className={(folio.id === currentID) ? 'current' : ''}><a id={folio.id} onClick={this.onClickThumb.bind(this, folio.id)}><img src={folio.image_thumbnail_url} alt={folio.name} /></a></figure>
         <figcaption className={(folio.id === currentID) ? 'thumbnail-caption current' : 'thumbnail-caption'}>

--- a/editioncrafter/src/component/ImageView.js
+++ b/editioncrafter/src/component/ImageView.js
@@ -136,6 +136,7 @@ const ImageView = (props) => {
           side={props.side}
           documentView={props.documentView}
           documentViewActions={props.documentViewActions}
+          documentName={props.document.variorum && props.document.folioIndex[props.folioID].doc_id}
         />
         <ImageZoomControl
           side={props.side}

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -22,6 +22,8 @@ const Navigation = (props) => {
   const [popover, setPopover] = useState({ ...initialPopoverObj });
   const [openHelp, setOpenHelp] = useState(false);
 
+  console.log(props.documentName);
+
   const helpRef = useRef(null);
 
   const onJumpBoxBlur = (event) => {
@@ -35,6 +37,10 @@ const Navigation = (props) => {
       event.target.value,
     );
   };
+
+  const onGoToGrid = (event) => {
+    props.documentViewActions.changeTranscriptionType(props.side, 'g');
+  }
 
   const toggleHelp = (event) => {
     setOpenHelp(!openHelp);
@@ -172,6 +178,14 @@ const Navigation = (props) => {
         { documentView[side].transcriptionType !== 'glossary' ? (
 
           <div id="tool-bar-buttons" className="breadcrumbs" style={showButtonsStyle}>
+              
+            <span 
+              className="fas fa-th" 
+              style={{ cursor: documentView[side].transcriptionType !== 'g' ? 'pointer' : 'default', padding: '0 15px' }} 
+              title={documentView[side].transcriptionType !== 'g' && "Return to Grid View"} 
+              onClick={documentView[side].transcriptionType !== 'g' && onGoToGrid} 
+            />
+
             <span
               title="Toggle coordination of views"
               onClick={toggleLockmode}
@@ -193,6 +207,7 @@ const Navigation = (props) => {
             {/* <span title="Toggle single column mode"  onClick={this.toggleColumns}
                                                     className={columnIconClass}></span> */}
                                               &nbsp;
+            
             <span
               title="Go back"
               onClick={changeCurrentFolio}
@@ -215,7 +230,7 @@ const Navigation = (props) => {
               <FaArrowCircleRight />
             </span>
                                               &nbsp;&nbsp;
-            {document.documentName}
+            {props.documentName || document.documentName}
             {' / '}
             <div
               onClick={revealJumpBox}
@@ -248,8 +263,8 @@ const Navigation = (props) => {
             id="doc-type"
             onClick={changeType}
           >
-            {Object.keys(props.document.transcriptionTypes).map(ttKey => (
-              <MenuItem value={ttKey} key={ttKey}>{props.document.transcriptionTypes[ttKey]}</MenuItem>
+            {Object.keys(props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).annotationURLs).map(ttKey => (
+              <MenuItem value={ttKey} key={ttKey}>{props.document.variorum ? props.document.transcriptionTypes[props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).doc_id][ttKey] : props.document.transcriptionTypes[ttKey]}</MenuItem>
             ))}
             <MenuItem value="f" key="f">
               {DocumentHelper.transcriptionTypeLabels.f}

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -22,8 +22,6 @@ const Navigation = (props) => {
   const [popover, setPopover] = useState({ ...initialPopoverObj });
   const [openHelp, setOpenHelp] = useState(false);
 
-  console.log(props.documentName);
-
   const helpRef = useRef(null);
 
   const onJumpBoxBlur = (event) => {
@@ -143,7 +141,7 @@ const Navigation = (props) => {
 
   const getSelectContainerStyle = () => {
     if (isWidthUp) {
-      if (documentView[side].width < 500) {
+      if (documentView[side].width < 500 && !document.variorum) {
         return { display: 'none' };
       }
 

--- a/editioncrafter/src/component/SplitPaneView.js
+++ b/editioncrafter/src/component/SplitPaneView.js
@@ -5,25 +5,28 @@ class SplitPaneView extends Component {
   constructor(props) {
     super();
     this.firstFolio = props.document.folios[0];
-
     // Initialize the splitter
-    this.rightPaneMinWidth = 200;
-    this.leftPaneMinWidth = 200;
-    this.splitFraction = 0.5;
+    this.rightPaneMinWidth = props.rightPane.props.documentView.right.transcriptionType === "glossary" ? 450 : 200;
+    this.leftPaneMinWidth = props.leftPane.props.documentView.left.transcriptionType === "glossary" ? 450 : 200;
+    this.thirdPaneMinWidth = props.thirdPane.props.documentView.third.transcriptionType === "glossary" ? 450 : props.thirdPane.props.documentView.third.transcriptionType === "g" ? 0 : 200;
+    this.splitFraction = 0.49;
+    this.splitFractionRight = 0.01;
     this.dividerWidth = 16;
     const whole = window.innerWidth;
-    const leftW = whole / 2;
+    const leftW = whole / 3;
 
     const split_left = (leftW / whole);
-    const split_right = 1 - split_left;
+    const split_right = (1 - split_left) / 2;
+    const split_third = 1 - split_left - split_right;
     this.state = {
       style: {
-        gridTemplateColumns: `${split_left}fr ${this.dividerWidth}px ${split_right}fr`,
+        gridTemplateColumns: `${split_left}fr ${this.dividerWidth}px ${split_right}fr ${this.dividerWidth}px ${split_third}fr`,
       },
     };
 
     // event handlers
     this.dragging = false;
+    this.activeDivider = 0;
     this.onDrag = this.onDrag.bind(this);
     this.onResize = this.onResize.bind(this);
     this.onEndDrag = this.onEndDrag.bind(this);
@@ -34,14 +37,26 @@ class SplitPaneView extends Component {
   // On drag, update the UI continuously
   onDrag = (e) => {
     if (this.dragging) {
-      const whole = window.innerWidth - this.dividerWidth;
-      const left_viewWidth = e.clientX - this.dividerWidth / 2;
-      const right_viewWidth = whole - left_viewWidth;
-
+      const whole = window.innerWidth - 2*this.dividerWidth;
+      let left_viewWidth;
+      let right_viewWidth;
+      let third_viewWidth;
+      if (this.activeDivider === 1) {
+        left_viewWidth = e.clientX - this.dividerWidth / 2;
+        third_viewWidth = whole*this.splitFractionRight;
+        right_viewWidth = whole - left_viewWidth - third_viewWidth;
+      }
+      else {
+        third_viewWidth = whole - e.clientX - this.dividerWidth / 2;
+        left_viewWidth = whole*this.splitFraction;
+        right_viewWidth = whole - left_viewWidth - third_viewWidth;
+      }
       // Update as long as we're within limits
       if (left_viewWidth > this.leftPaneMinWidth
-        && right_viewWidth > this.rightPaneMinWidth) {
+        && right_viewWidth > this.rightPaneMinWidth
+        && third_viewWidth > this.thirdPaneMinWidth) {
         this.splitFraction = (whole === 0) ? 0.0 : left_viewWidth / whole;
+        this.splitFractionRight = (whole === 0) ? 0.0 : third_viewWidth / whole;
         this.updateUI();
       }
 
@@ -50,13 +65,15 @@ class SplitPaneView extends Component {
   };
 
   // Drag start: mark it
-  onStartDrag = (e) => {
+  onStartDrag = (position) => {
     this.dragging = true;
+    this.activeDivider = position === 'first' ? 1 : 2;
   };
 
   // Drag end
   onEndDrag = (e) => {
     this.dragging = false;
+    this.activeDivider = 0;
   };
 
   // On window resize
@@ -67,12 +84,13 @@ class SplitPaneView extends Component {
   // Update the screen with the new split info
   updateUI() {
     const left = this.splitFraction;
-    const right = 1.0 - left;
+    const third = this.splitFractionRight;
+    const right = 1.0 - left - third;
     this.setState({
       ...this.state,
       style: {
         ...this.state.style,
-        gridTemplateColumns: `${left}fr ${this.dividerWidth}px ${right}fr`,
+        gridTemplateColumns: `${left}fr ${this.dividerWidth}px ${right}fr ${this.dividerWidth}px ${third}fr`,
       },
     });
   }
@@ -81,9 +99,10 @@ class SplitPaneView extends Component {
   updatePaneSize() {
     // Record state change
     const left_px = Math.floor(Math.abs(window.innerWidth * this.splitFraction));
-    const right_px = Math.floor(window.innerWidth * (1.0 - this.splitFraction));
-    if (this.props.onWidth && left_px >= this.leftPaneMinWidth) {
-      this.props.onWidth(left_px, right_px);
+    const third_px = Math.floor(Math.abs(window.innerWidth * this.splitFractionRight));
+    const right_px = Math.floor(window.innerWidth * (1.0 - this.splitFraction - this.splitFractionRight));
+    if (this.props.onWidth && left_px >= this.leftPaneMinWidth && right_px >= this.rightPaneMinWidth && third_px >= this.thirdPaneMinWidth) {
+      this.props.onWidth(left_px, right_px, third_px);
     }
   }
 
@@ -92,13 +111,20 @@ class SplitPaneView extends Component {
     window.addEventListener('mousemove', this.onDrag);
     window.addEventListener('mouseup', this.onEndDrag);
     window.addEventListener('resize', this.onResize);
-
+    console.log(this.props);
     // Set the default width on mount
     if (this.props.onWidth) {
       const left_px = Math.floor(Math.abs(window.innerWidth * this.splitFraction));
       const right_px = Math.floor(window.innerWidth * (1.0 - this.splitFraction));
-      this.props.onWidth(left_px, right_px);
+      const third_px = Math.floor(window.innerWidth * (1.0 - this.splitFraction));
+      this.props.onWidth(left_px, right_px, third_px);
     }
+  }
+
+  componentDidUpdate(prevProps) {
+    this.rightPaneMinWidth = this.props.rightPane.props.documentView.right.transcriptionType === "glossary" ? 450 : 200;
+    this.leftPaneMinWidth = this.props.leftPane.props.documentView.left.transcriptionType === "glossary" ? 450 : 200;
+    this.thirdPaneMinWidth = this.props.thirdPane.props.documentView.third.transcriptionType === "glossary" ? 450 : this.props.thirdPane.props.documentView.third.transcriptionType === "g" ? 0 : 200;
   }
 
   componentWillUnmount() {
@@ -107,11 +133,11 @@ class SplitPaneView extends Component {
     window.removeEventListener('resize', this.onResize);
   }
 
-  renderDivider() {
+  renderDivider(position) {
     const drawerIconClass = 'drawer-icon fas fa-caret-left fa-2x';
 
     return (
-      <div className="divider" onMouseDown={this.onStartDrag}>
+      <div className={`divider ${position}_divider`} onMouseDown={() => this.onStartDrag(position)}>
         <div className="drawer-button hidden" onClick={this.onDrawerButton}>
           <i className={drawerIconClass}> </i>
         </div>
@@ -121,10 +147,12 @@ class SplitPaneView extends Component {
 
   render() {
     return (
-      <div className="split-pane-view" style={{ ...this.state.style }}>
+      <div className="split-pane-view three-pane" style={{ ...this.state.style }}>
         { this.props.leftPane }
-        { this.renderDivider() }
+        { this.renderDivider('first') }
         { this.props.rightPane }
+        { this.renderDivider('second') }
+        { this.props.thirdPane }
       </div>
     );
   }

--- a/editioncrafter/src/component/SplitPaneView.js
+++ b/editioncrafter/src/component/SplitPaneView.js
@@ -9,8 +9,8 @@ class SplitPaneView extends Component {
     this.rightPaneMinWidth = props.rightPane.props.documentView.right.transcriptionType === "glossary" ? 450 : 200;
     this.leftPaneMinWidth = props.leftPane.props.documentView.left.transcriptionType === "glossary" ? 450 : 200;
     this.thirdPaneMinWidth = props.thirdPane.props.documentView.third.transcriptionType === "glossary" ? 450 : props.thirdPane.props.documentView.third.transcriptionType === "g" ? 0 : 200;
-    this.splitFraction = 0.49;
-    this.splitFractionRight = 0.01;
+    this.splitFraction = props.threePanel ? 0.49 : 0.5;
+    this.splitFractionRight = props.threePanel ? 0.01 : 0;
     this.dividerWidth = 16;
     const whole = window.innerWidth;
     const leftW = whole / 3;
@@ -52,9 +52,9 @@ class SplitPaneView extends Component {
         right_viewWidth = whole - left_viewWidth - third_viewWidth;
       }
       // Update as long as we're within limits
-      if (left_viewWidth > this.leftPaneMinWidth
-        && right_viewWidth > this.rightPaneMinWidth
-        && third_viewWidth > this.thirdPaneMinWidth) {
+      if (left_viewWidth >= this.leftPaneMinWidth
+        && right_viewWidth >= this.rightPaneMinWidth
+        && third_viewWidth >= this.thirdPaneMinWidth) {
         this.splitFraction = (whole === 0) ? 0.0 : left_viewWidth / whole;
         this.splitFractionRight = (whole === 0) ? 0.0 : third_viewWidth / whole;
         this.updateUI();
@@ -151,8 +151,8 @@ class SplitPaneView extends Component {
         { this.props.leftPane }
         { this.renderDivider('first') }
         { this.props.rightPane }
-        { this.renderDivider('second') }
-        { this.props.thirdPane }
+        { this.props.threePanel && this.renderDivider('second') }
+        { this.props.threePanel && this.props.thirdPane }
       </div>
     );
   }

--- a/editioncrafter/src/component/TranscriptionView.js
+++ b/editioncrafter/src/component/TranscriptionView.js
@@ -147,6 +147,7 @@ const TranscriptionView = (props) => {
         side={side}
         documentView={documentView}
         documentViewActions={documentViewActions}
+        documentName={document.variorum && folio.doc_id}
       />
       <Pagination side={side} documentView={documentView} documentViewActions={documentViewActions} />
       <div className="transcriptionViewComponent">

--- a/editioncrafter/src/component/Watermark.js
+++ b/editioncrafter/src/component/Watermark.js
@@ -10,7 +10,7 @@ const Watermark = ({ side, documentView, documentViewActions }) => (
     <div className="transcriptContent">
       <Pagination side={side} className="pagination_upper" documentView={documentView} documentViewActions={documentViewActions} />
       <div className="watermark">
-        <div className="watermark_contents" />
+        <div className={ side !== 'third' ? "watermark_contents" : "third_pane_blank"} />
       </div>
     </div>
   </div>

--- a/editioncrafter/src/component/XMLView.js
+++ b/editioncrafter/src/component/XMLView.js
@@ -41,7 +41,7 @@ class XMLView extends Component {
 
     return (
       <div id={thisID} className={thisClass}>
-        <Navigation side={side} documentView={documentView} documentViewActions={documentViewActions} />
+        <Navigation side={side} documentView={documentView} documentViewActions={documentViewActions} documentName={document.variorum && folio.doc_id}/>
         <Pagination side={side} className="pagination_upper" documentView={documentView} documentViewActions={documentViewActions} />
 
         <div className="xmlContentInner">

--- a/editioncrafter/src/index.js
+++ b/editioncrafter/src/index.js
@@ -21,7 +21,7 @@ const EditionCrafter = (props) => {
 
   return (
     <ThemeProvider theme={theme}>
-      <DiploMatic config={props.config} store={createReduxStore(props.config)} />
+      <DiploMatic config={props} store={createReduxStore(props)} />
     </ThemeProvider>
   );
 };

--- a/editioncrafter/src/model/ReduxStore.js
+++ b/editioncrafter/src/model/ReduxStore.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-cycle */
 import { createStore, applyMiddleware } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 import { put } from 'redux-saga/effects';

--- a/editioncrafter/src/saga/RouteListenerSaga.js
+++ b/editioncrafter/src/saga/RouteListenerSaga.js
@@ -56,16 +56,20 @@ function* resolveFolio(pathSegments) {
   const document = yield select(justDocument);
   if (document.loaded) {
     let leftID; let
-      rightID;
+      rightID; let thirdID;
     if (pathSegments.length > 2) {
       leftID = pathSegments[2];
       if (pathSegments.length > 4) {
         rightID = pathSegments[4];
+        if (pathSegments.length > 6) {
+          thirdID = pathSegments[6];
+        }
       }
     }
     const folioIDs = [];
     folioIDs.push(leftID);
     if (rightID && rightID !== leftID) folioIDs.push(rightID);
+    if (thirdID && thirdID !== leftID && thirdID !== rightID) folioIDs.push(thirdID);
 
     for (const folioID of folioIDs) {
       const folioData = document.folioIndex[folioID];

--- a/editioncrafter/src/scss/_CETEIcean.scss
+++ b/editioncrafter/src/scss/_CETEIcean.scss
@@ -425,7 +425,7 @@ tei-cell item {
 /* l */
 tei-l {
   display: block;
-  width: 35em;
+  //width: 35em;
 }
 tei-l[data-lineno]:before {
   content: attr(data-lineno);

--- a/editioncrafter/src/scss/_imageGridView.scss
+++ b/editioncrafter/src/scss/_imageGridView.scss
@@ -59,5 +59,15 @@
 				cursor: pointer;
 			}
 		}
+
+		.doc-select {
+			display: inline;
+			margin-left: 30px;
+			font-size: 0.8rem;
+
+			.MuiInputBase-root {
+				font-size: 0.8rem;
+			}
+		}
 	}
 }

--- a/editioncrafter/src/scss/_imageView.scss
+++ b/editioncrafter/src/scss/_imageView.scss
@@ -1,6 +1,7 @@
 
 #image-view-seadragon-left,
-#image-view-seadragon-right {
+#image-view-seadragon-right,
+#image-view-seadragon-third {
   width: 100%;
   height: 100%;
   grid-area: image_viewer;

--- a/editioncrafter/src/scss/_splitPaneView.scss
+++ b/editioncrafter/src/scss/_splitPaneView.scss
@@ -2,16 +2,30 @@
   height: 100%;
   width: 100%;
   display: grid;
+}
+
+.split-pane-view.two-pane {
   grid-template-areas: "image_viewer divider transcription";
+}
+
+.split-pane-view.three-pane {
+  grid-template-areas: "image_viewer divider transcription divider_two third_pane";
 }
 
 .split-pane-view > .divider {
     z-index: 2;
-    grid-area: divider;
     width: 1rem;
     background: #BBB;
     cursor:ew-resize;
     display: flex;
+}
+
+.split-pane-view > .divider.first_divider {
+  grid-area: divider;
+}
+
+.split-pane-view > .divider.second_divider {
+  grid-area: divider_two;
 }
 
 .split-pane-view > .divider > .drawer-button {

--- a/editioncrafter/src/scss/_watermark.scss
+++ b/editioncrafter/src/scss/_watermark.scss
@@ -17,3 +17,7 @@ $watermark-size: 10rem;
 	background-repeat: no-repeat;
 	margin: auto auto auto auto;
 }
+
+.third_pane_blank {
+	min-width: 8px;
+}

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -1,56 +1,53 @@
 import React from 'react';
 import EditionCrafter from '../src/index';
 
-// export const BowInTheCloud = () => (
-//   <EditionCrafter config={{
-//     documentName: 'eng-415-145a',
-//     transcriptionTypes: {
-//       'eng-415-145a': 'Transcription'
-//     },
-//     iiifManifest: 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json',
-//   }}
-//   />
-// );
+export const BowInTheCloud = () => (
+  <EditionCrafter
+    documentName='eng-415-145a'
+    transcriptionTypes={{
+      'eng-415-145a': 'Transcription'
+    }}
+    iiifManifest='https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json'
+  />
+);
 
-// export const DyngleyFamily = () => (
-//   <EditionCrafter config={{
-//     documentName: 'O.8.35',
-//     transcriptionTypes: {
-//       transcription: 'Translation',
-//     },
-//     iiifManifest: 'https://cu-mkp.github.io/dyngleyfamily-editioncrafter-data/O_8_35/iiif/manifest.json',
-//   }}
-//   />
-// );
+export const DyngleyFamily = () => (
+  <EditionCrafter
+    documentName='O.8.35'
+    transcriptionTypes={{
+      transcription: 'Translation',
+    }}
+    iiifManifest='https://cu-mkp.github.io/dyngleyfamily-editioncrafter-data/O_8_35/iiif/manifest.json'
+  />
+);
 
-// export const NativeBoundUnbound = () => (
-//   <EditionCrafter config={{
-//     documentName: 'FHL_007548733_TAOS_BAPTISMS_BATCH_2',
-//     transcriptionTypes: {
-//       translation: 'Translation',
-//       transcription: 'Transcription',
-//     },
-//     iiifManifest: 'https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json',
-//   }}
-//   />
-// );
+export const NativeBoundUnbound = () => (
+  <EditionCrafter
+    documentName='FHL_007548733_TAOS_BAPTISMS_BATCH_2'
+    transcriptionTypes={{
+      translation: 'Translation',
+      transcription: 'Transcription',
+    }}
+    iiifManifest='https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json'
+  />
+);
 
-// export const BnFMsFr640 = () => (
-//   <EditionCrafter config={{
-//     documentName: 'BnF Ms. Fr. 640',
-//     transcriptionTypes: {
-//       tc: 'Diplomatic (FR)',
-//       tcn: 'Normalized (FR)',
-//       tl: 'Translation (EN)',
-//       test: 'Test Field (EN)',
-//     },
-//     iiifManifest: 'https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json',
-//   }}
-//   />
-// );
+export const BnFMsFr640 = () => (
+  <EditionCrafter
+    documentName='BnF Ms. Fr. 640'
+    transcriptionTypes={{
+      tc: 'Diplomatic (FR)',
+      tcn: 'Normalized (FR)',
+      tl: 'Translation (EN)',
+      test: 'Test Field (EN)',
+    }}
+    iiifManifest='https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json'
+  />
+);
 
 export const IntervistePescatori = () => (
   <EditionCrafter
+    threePanel
     documentName='Interviste Pescatori 1r-35v'
     transcriptionTypes={{
       transcription: 'Transcription'
@@ -62,7 +59,7 @@ export const IntervistePescatori = () => (
 export const MultiDocument = () => (
   <EditionCrafter
     documentName='FHL_007548733_TAOS_BAPTISMS_BATCH_2 and eng-415-145a'
-    variorum
+    threePanel
     documentInfo={{
       FHL_007548733_TAOS_BAPTISMS_BATCH_2: {
         documentName: 'Taos Baptisms Batch 2',

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -1,70 +1,69 @@
 import React from 'react';
 import EditionCrafter from '../src/index';
 
-export const BowInTheCloud = () => (
-  <EditionCrafter config={{
-    documentName: 'eng-415-145a',
-    transcriptionTypes: {
-      'eng-415-145a': 'Transcription'
-    },
-    iiifManifest: 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json',
-  }}
-  />
-);
+// export const BowInTheCloud = () => (
+//   <EditionCrafter config={{
+//     documentName: 'eng-415-145a',
+//     transcriptionTypes: {
+//       'eng-415-145a': 'Transcription'
+//     },
+//     iiifManifest: 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json',
+//   }}
+//   />
+// );
 
-export const DyngleyFamily = () => (
-  <EditionCrafter config={{
-    documentName: 'O.8.35',
-    transcriptionTypes: {
-      transcription: 'Translation',
-    },
-    iiifManifest: 'https://cu-mkp.github.io/dyngleyfamily-editioncrafter-data/O_8_35/iiif/manifest.json',
-  }}
-  />
-);
+// export const DyngleyFamily = () => (
+//   <EditionCrafter config={{
+//     documentName: 'O.8.35',
+//     transcriptionTypes: {
+//       transcription: 'Translation',
+//     },
+//     iiifManifest: 'https://cu-mkp.github.io/dyngleyfamily-editioncrafter-data/O_8_35/iiif/manifest.json',
+//   }}
+//   />
+// );
 
-export const NativeBoundUnbound = () => (
-  <EditionCrafter config={{
-    documentName: 'FHL_007548733_TAOS_BAPTISMS_BATCH_2',
-    transcriptionTypes: {
-      translation: 'Translation',
-      transcription: 'Transcription',
-    },
-    iiifManifest: 'https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json',
-  }}
-  />
-);
+// export const NativeBoundUnbound = () => (
+//   <EditionCrafter config={{
+//     documentName: 'FHL_007548733_TAOS_BAPTISMS_BATCH_2',
+//     transcriptionTypes: {
+//       translation: 'Translation',
+//       transcription: 'Transcription',
+//     },
+//     iiifManifest: 'https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json',
+//   }}
+//   />
+// );
 
-export const BnFMsFr640 = () => (
-  <EditionCrafter config={{
-    documentName: 'BnF Ms. Fr. 640',
-    transcriptionTypes: {
-      tc: 'Diplomatic (FR)',
-      tcn: 'Normalized (FR)',
-      tl: 'Translation (EN)',
-      test: 'Test Field (EN)',
-    },
-    iiifManifest: 'https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json',
-  }}
-  />
-);
+// export const BnFMsFr640 = () => (
+//   <EditionCrafter config={{
+//     documentName: 'BnF Ms. Fr. 640',
+//     transcriptionTypes: {
+//       tc: 'Diplomatic (FR)',
+//       tcn: 'Normalized (FR)',
+//       tl: 'Translation (EN)',
+//       test: 'Test Field (EN)',
+//     },
+//     iiifManifest: 'https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json',
+//   }}
+//   />
+// );
 
 export const IntervistePescatori = () => (
-  <EditionCrafter config={{
-    documentName: 'Interviste Pescatori 1r-35v',
-    transcriptionTypes: {
+  <EditionCrafter
+    documentName='Interviste Pescatori 1r-35v'
+    transcriptionTypes={{
       transcription: 'Transcription'
-    },
-    iiifManifest: 'https://cu-mkp.github.io/venice-editioncrafter-data/data/interviste-pescatori_1r-35v/iiif/manifest.json',
-  }}
+    }}
+    iiifManifest='https://cu-mkp.github.io/venice-editioncrafter-data/data/interviste-pescatori_1r-35v/iiif/manifest.json'
   />
 );
 
 export const MultiDocument = () => (
-  <EditionCrafter config={{
-    documentName: 'FHL_007548733_TAOS_BAPTISMS_BATCH_2 and eng-415-145a',
-    variorum: true,
-    documentInfo: {
+  <EditionCrafter
+    documentName='FHL_007548733_TAOS_BAPTISMS_BATCH_2 and eng-415-145a'
+    variorum
+    documentInfo={{
       FHL_007548733_TAOS_BAPTISMS_BATCH_2: {
         documentName: 'Taos Baptisms Batch 2',
         transcriptionTypes: {
@@ -80,8 +79,7 @@ export const MultiDocument = () => (
         },
         iiifManifest: 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json',
       },
-    },
-  }}
+    }}
   />
 );
 

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -60,6 +60,31 @@ export const IntervistePescatori = () => (
   />
 );
 
+export const MultiDocument = () => (
+  <EditionCrafter config={{
+    documentName: 'FHL_007548733_TAOS_BAPTISMS_BATCH_2 and eng-415-145a',
+    variorum: true,
+    documentInfo: {
+      FHL_007548733_TAOS_BAPTISMS_BATCH_2: {
+        documentName: 'Taos Baptisms Batch 2',
+        transcriptionTypes: {
+          translation: 'Translation',
+          transcription: 'Transcription',
+        },
+        iiifManifest: 'https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json',
+      },
+      eng_415_145a: {
+        documentName: 'Eng 415-145a',
+        transcriptionTypes: {
+          'eng-415-145a': 'Transcription',
+        },
+        iiifManifest: 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json',
+      },
+    },
+  }}
+  />
+);
+
 export default {
   title: 'EditionCrafter',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "name": "@cu-mkp/edition-crafter-monorepo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@cu-mkp/edition-crafter-monorepo",
+      "license": "MIT"
+    }
+  }
+}


### PR DESCRIPTION
### In this PR

This PR adds several features and new functionality to the `EditionCrafter` component. Specifically:
- Adds the ability to pass a `documentInfo` prop to the component that is an object keyed with document names and containing configuration info for multiple different documents. For example (from the Storybook examples):
```  
<EditionCrafter
    documentName='FHL_007548733_TAOS_BAPTISMS_BATCH_2 and eng-415-145a'
    threePanel
    documentInfo={{
      FHL_007548733_TAOS_BAPTISMS_BATCH_2: {
        documentName: 'Taos Baptisms Batch 2',
        transcriptionTypes: {
          translation: 'Translation',
          transcription: 'Transcription',
        },
        iiifManifest: 'https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json',
      },
      eng_415_145a: {
        documentName: 'Eng 415-145a',
        transcriptionTypes: {
          'eng-415-145a': 'Transcription',
        },
        iiifManifest: 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json',
      },
    }}
  />
```
If multiple documents are passed to the component this way, then by default the viewer will display folios from the first document in the first pane and from the second document in the second:
![image](https://github.com/cu-mkp/editioncrafter/assets/110847635/50a16cec-cd65-4ede-bb48-427d5f04267f)
You can then use a dropdown to select different documents for each pane:
![image](https://github.com/cu-mkp/editioncrafter/assets/110847635/b54af1a6-56f3-452c-b32c-afe346a608d0)
This feature enables easy comparison of folios from multiple documents or different versions of the same document between the different panes.

- Optional three-pane view: There is now a `threePane` prop that can be optionally passed to the component which will display a third view pane in the viewer. The third pane begins "tucked away" on the right side of the screen by default, and can be resized by dragging the divider. 
![image](https://github.com/cu-mkp/editioncrafter/assets/110847635/af212c7a-43fd-4f99-91d2-950bffa680f4)

- Simplification of component props: As evidenced in the example two bullet points above this, information such as the document/project name, `threePanel` flag, and `documentInfo` can now be passed directly to the component as props, rather than being bundled into a `config` JavaScript object and passed as a single prop. In the case of a single document rather than a variorum, the new prop structure looks like, for example: 
```
  <EditionCrafter
    threePanel
    documentName='Interviste Pescatori 1r-35v'
    transcriptionTypes={{
      transcription: 'Transcription'
    }}
    iiifManifest='https://cu-mkp.github.io/venice-editioncrafter-data/data/interviste-pescatori_1r-35v/iiif/manifest.json'
  />
```