### PR TITLE
Updates to styling and reactiveness

### DIFF
--- a/editioncrafter/src/component/DiploMatic.js
+++ b/editioncrafter/src/component/DiploMatic.js
@@ -1,7 +1,7 @@
 import withWidth from '@material-ui/core/withWidth';
 import { createBrowserHistory } from 'history';
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { connect, Provider } from 'react-redux';
 import {
   HashRouter, Route, Navigate, Routes,
@@ -10,12 +10,20 @@ import DocumentView from './DocumentView';
 import RouteListener from './RouteListener';
 
 const DiploMatic = (props) => {
+  const [containerWidth, setContainerWidth] = useState(0);
+  const containerRef = useRef(null)
   useEffect(() => {
     const history = createBrowserHistory();
     history.listen(() => {
       window.scrollTo(0, 0);
     });
-  });
+  }, []);
+
+  useEffect(() => {
+    if(containerRef.current){ 
+      setContainerWidth(containerRef.current.offsetWidth);  
+    }
+  }, [containerRef]);
 
   const { fixedFrameMode } = props.diplomatic;
   const fixedFrameModeClass = fixedFrameMode ? 'fixed' : 'sticky';
@@ -23,15 +31,15 @@ const DiploMatic = (props) => {
   return (
     <Provider store={props.store}>
       <HashRouter>
-        <div id="diplomatic" className={fixedFrameModeClass}>
+        <div id="diplomatic" className={fixedFrameModeClass} ref={containerRef}>
           <RouteListener />
           <div id="content">
             <Routes>
-              <Route path="/ec/:folioID/:transcriptionType/:folioID2/:transcriptionType2/:folioID3/:transcriptionType3" element={<DocumentView {...props} />} exact />
-              <Route path="/ec/:folioID/:transcriptionType/:folioID2/:transcriptionType2" element={<DocumentView {...props} />} exact />
-              <Route path="/ec/:folioID/:transcriptionType" element={<DocumentView {...props} />} exact />
-              <Route path="/ec/:folioID" element={<DocumentView {...props} />} exact />
-              <Route path="/ec" element={<DocumentView {...props} />} exact />
+              <Route path="/ec/:folioID/:transcriptionType/:folioID2/:transcriptionType2/:folioID3/:transcriptionType3" element={<DocumentView {...props} containerWidth={containerWidth} />} exact />
+              <Route path="/ec/:folioID/:transcriptionType/:folioID2/:transcriptionType2" element={<DocumentView {...props} containerWidth={containerWidth} />} exact />
+              <Route path="/ec/:folioID/:transcriptionType" element={<DocumentView {...props} containerWidth={containerWidth} />} exact />
+              <Route path="/ec/:folioID" element={<DocumentView {...props} containerWidth={containerWidth} />} exact />
+              <Route path="/ec" element={<DocumentView {...props} containerWidth={containerWidth} />} exact />
               <Route path="/" element={<Navigate to="/ec" />} exact />
             </Routes>
           </div>

--- a/editioncrafter/src/component/DocumentView.js
+++ b/editioncrafter/src/component/DocumentView.js
@@ -301,7 +301,6 @@ const DocumentView = (props) => {
   };
 
   const determineViewType = (side) => {
-    console.log(side, getViewports());
     const { transcriptionType } = getViewports()[side];
     const xmlMode = side === 'left'
       ? left.isXMLMode
@@ -477,9 +476,6 @@ const DocumentView = (props) => {
     left,
     right: { ...viewportState('right') },
   };
-
-  console.log('left', viewportState('left'));
-  console.log('right', viewportState('right'));
 
   if (isWidthUp('md', props.width) && !singlePaneMode) {
     return (

--- a/editioncrafter/src/component/DocumentView.js
+++ b/editioncrafter/src/component/DocumentView.js
@@ -24,10 +24,15 @@ const DocumentView = (props) => {
   const [left, setLeft] = useState(paneDefaults);
   const [right, setRight] = useState(paneDefaults);
   const [third, setThird] = useState(paneDefaults);
+  const [singlePaneMode, setSinglePaneMode] = useState(props.containerWidth < 960);
 
   const params = useParams();
   const navigate = useNavigate();
   const location = useLocation();
+
+  useEffect(() => {
+    setSinglePaneMode(props.containerWidth < 960);
+  }, [props.containerWidth]);
 
   // Navigate while keeping existing search params
   const navigateWithParams = (pathname) => {
@@ -296,6 +301,7 @@ const DocumentView = (props) => {
   };
 
   const determineViewType = (side) => {
+    console.log(side, getViewports());
     const { transcriptionType } = getViewports()[side];
     const xmlMode = side === 'left'
       ? left.isXMLMode
@@ -472,7 +478,10 @@ const DocumentView = (props) => {
     right: { ...viewportState('right') },
   };
 
-  if (isWidthUp('md', props.width)) {
+  console.log('left', viewportState('left'));
+  console.log('right', viewportState('right'));
+
+  if (isWidthUp('md', props.width) && !singlePaneMode) {
     return (
       <div>
         <SplitPaneView
@@ -488,7 +497,7 @@ const DocumentView = (props) => {
   return (
     <div>
       <SinglePaneView
-        singlePane={renderPane('right', mobileDocView)}
+        singlePane={renderPane(viewportState('left').iiifShortID === "-1" ? 'left' : 'right', docView)}
       />
     </div>
   );

--- a/editioncrafter/src/component/ImageView.js
+++ b/editioncrafter/src/component/ImageView.js
@@ -12,6 +12,7 @@ import ImageZoomControl from './ImageZoomControl';
 import SeaDragonComponent from './SeaDragonComponent';
 
 import '@recogito/annotorious-openseadragon/dist/annotorious.min.css';
+import { BigRingSpinner } from './RingSpinner';
 
 const ImageView = (props) => {
   const [viewer, setViewer] = useState(null);
@@ -21,6 +22,7 @@ const ImageView = (props) => {
   const navigate = useNavigate();
 
   const [searchParams] = useSearchParams();
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (anno && searchParams.get('zone')) {
@@ -119,18 +121,24 @@ const ImageView = (props) => {
 
   useEffect(() => {
     const folio = props.document.folioIndex[props.folioID];
+    if (folio.loading) {
+      setLoading(true);
+    }
     if (folio.tileSource && viewer) {
       viewer.open(folio.tileSource);
       if (folio.annotations && anno) {
         anno.setAnnotations(folio.annotations);
       }
     }
+    if (!folio.loading) {
+      setLoading(false);
+    }
   }, [anno, viewer, props.folioID, props.document.folioIndex]);
 
   return (
     <div>
       { tileSource
-      && (
+      ? (
       <div className={`image-view imageViewComponent ${props.side}`}>
         <Navigation
           side={props.side}
@@ -153,8 +161,11 @@ const ImageView = (props) => {
           side={props.side}
           tileSource={tileSource}
           initViewer={initViewer}
+          loading={loading}
         />
       </div>
+      ) : (
+        <BigRingSpinner color="dark" delay={300} />
       )}
     </div>
   );

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -309,6 +309,32 @@ const Navigation = (props) => {
                 className={imageViewActive ? 'invisible' : xmlIconClass}
               />
 
+              { imageViewActive && (
+                <>
+                  <span
+                  title="Go back"
+                  onClick={changeCurrentFolio}
+                  data-id={documentView[side].previousFolioShortID}
+                  className={(documentView[side].hasPrevious) ? 'arrow' : 'arrow disabled'}
+                >
+                  {' '}
+                  <FaArrowCircleLeft />
+                  {' '}
+  
+                </span>
+  
+                <span
+                  title="Go forward"
+                  onClick={changeCurrentFolio}
+                  data-id={documentView[side].nextFolioShortID}
+                  className={(documentView[side].hasNext) ? 'arrow' : 'arrow disabled'}
+                >
+                  {' '}
+                  <FaArrowCircleRight />
+                </span>
+                </>
+              )}
+
             </div>
           )
             : (<AlphabetLinks onFilterChange={onFilterChange} value={props.value} />)}

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -156,7 +156,7 @@ const Navigation = (props) => {
   const selectColorStyle = documentView[side].transcriptionType === 'f' ? { color: 'white' } : { color: 'black' };
   const selectClass = documentView[side].transcriptionType === 'f' ? 'dark' : 'light';
   const showButtonsStyle = documentView[side].transcriptionType === 'glossary' ? { visibility: 'hidden' } : { visibility: 'visible' };
-  const selectContainerStyle = getSelectContainerStyle();
+  const selectContainerStyle = { display: 'flex' }; //what's the reason we want this to be hidden sometimes?
   let lockIconClass = (documentView.linkedMode) ? 'fa fa-lock' : 'fa fa-lock-open';
   if (!documentView.bookMode) {
     lockIconClass += ' active';

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -170,124 +170,185 @@ const Navigation = (props) => {
   const helpMarginStyle = side === 'left' ? { marginRight: '55px' } : { marginRight: '15px' };
 
   return (
-    <div className="navigationComponent" style={widthStyle}>
-      <div id="navigation-row" className="navigationRow">
+    <>
+      <div className="navigationComponent" style={widthStyle}>
+        <div id="navigation-row" className="navigationRow">
 
-        { documentView[side].transcriptionType !== 'glossary' ? (
+          { documentView[side].transcriptionType !== 'glossary' ? (
 
-          <div id="tool-bar-buttons" className="breadcrumbs" style={showButtonsStyle}>
+            <div id="tool-bar-buttons" className="breadcrumbs" style={showButtonsStyle}>
+                
+              <span 
+                className="fas fa-th" 
+                style={{ cursor: documentView[side].transcriptionType !== 'g' ? 'pointer' : 'default', padding: '0 15px' }} 
+                title={documentView[side].transcriptionType !== 'g' && "Return to Grid View"} 
+                onClick={documentView[side].transcriptionType !== 'g' && onGoToGrid} 
+              />
+
+              <span
+                title="Toggle coordination of views"
+                onClick={toggleLockmode}
+                className={lockIconClass}
+              />
+                                                &nbsp;
+              <span
+                title="Toggle book mode"
+                onClick={toggleBookmode}
+                className={bookIconClass}
+              />
+                                                &nbsp;
+              <span
+                title="Toggle XML mode"
+                onClick={toggleXMLMode}
+                className={imageViewActive ? 'invisible' : xmlIconClass}
+              />
+                                                &nbsp;
+              {/* <span title="Toggle single column mode"  onClick={this.toggleColumns}
+                                                      className={columnIconClass}></span> */}
+                                                &nbsp;
               
-            <span 
-              className="fas fa-th" 
-              style={{ cursor: documentView[side].transcriptionType !== 'g' ? 'pointer' : 'default', padding: '0 15px' }} 
-              title={documentView[side].transcriptionType !== 'g' && "Return to Grid View"} 
-              onClick={documentView[side].transcriptionType !== 'g' && onGoToGrid} 
-            />
+              <span
+                title="Go back"
+                onClick={changeCurrentFolio}
+                data-id={documentView[side].previousFolioShortID}
+                className={(documentView[side].hasPrevious) ? 'arrow' : 'arrow disabled'}
+              >
+                {' '}
+                <FaArrowCircleLeft />
+                {' '}
 
-            <span
-              title="Toggle coordination of views"
-              onClick={toggleLockmode}
-              className={lockIconClass}
-            />
-                                              &nbsp;
-            <span
-              title="Toggle book mode"
-              onClick={toggleBookmode}
-              className={bookIconClass}
-            />
-                                              &nbsp;
-            <span
-              title="Toggle XML mode"
-              onClick={toggleXMLMode}
-              className={imageViewActive ? 'invisible' : xmlIconClass}
-            />
-                                              &nbsp;
-            {/* <span title="Toggle single column mode"  onClick={this.toggleColumns}
-                                                    className={columnIconClass}></span> */}
-                                              &nbsp;
-            
-            <span
-              title="Go back"
-              onClick={changeCurrentFolio}
-              data-id={documentView[side].previousFolioShortID}
-              className={(documentView[side].hasPrevious) ? 'arrow' : 'arrow disabled'}
-            >
-              {' '}
-              <FaArrowCircleLeft />
-              {' '}
+              </span>
 
-            </span>
+              <span
+                title="Go forward"
+                onClick={changeCurrentFolio}
+                data-id={documentView[side].nextFolioShortID}
+                className={(documentView[side].hasNext) ? 'arrow' : 'arrow disabled'}
+              >
+                {' '}
+                <FaArrowCircleRight />
+              </span>
+                                                &nbsp;&nbsp;
+              {props.documentName || document.documentName}
+              {' / '}
+              <div
+                onClick={revealJumpBox}
+                className="folioName"
+              >
+                {' '}
+                {folioName}
+                {' '}
+                <span style={jumpToIconStyle} className="fa fa-hand-point-right" />
+              </div>
 
-            <span
-              title="Go forward"
-              onClick={changeCurrentFolio}
-              data-id={documentView[side].nextFolioShortID}
-              className={(documentView[side].hasNext) ? 'arrow' : 'arrow disabled'}
-            >
-              {' '}
-              <FaArrowCircleRight />
-            </span>
-                                              &nbsp;&nbsp;
-            {props.documentName || document.documentName}
-            {' / '}
-            <div
-              onClick={revealJumpBox}
-              className="folioName"
-            >
-              {' '}
-              {folioName}
-              {' '}
-              <span style={jumpToIconStyle} className="fa fa-hand-point-right" />
+              <JumpToFolio
+                side={side}
+                isVisible={popover.show}
+                positionX={popover.x}
+                positionY={popover.y}
+                submitHandler={documentViewActions.jumpToFolio}
+                blurHandler={onJumpBoxBlur}
+              />
+
             </div>
+          )
+            : (<AlphabetLinks onFilterChange={onFilterChange} value={props.value} />)}
 
-            <JumpToFolio
-              side={side}
-              isVisible={popover.show}
-              positionX={popover.x}
-              positionY={popover.y}
-              submitHandler={documentViewActions.jumpToFolio}
-              blurHandler={onJumpBoxBlur}
+          <div id="doc-type-help" style={selectContainerStyle} ref={e => { helpRef.current = e; }}>
+            <Select
+              className={selectClass}
+              style={{ ...selectColorStyle, marginRight: 15 }}
+              value={documentView[side].transcriptionType}
+              id="doc-type"
+              onClick={changeType}
+            >
+              {Object.keys(props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).annotationURLs).map(ttKey => (
+                <MenuItem value={ttKey} key={ttKey}>{props.document.variorum ? props.document.transcriptionTypes[props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).doc_id][ttKey] : props.document.transcriptionTypes[ttKey]}</MenuItem>
+              ))}
+              <MenuItem value="f" key="f">
+                {DocumentHelper.transcriptionTypeLabels.f}
+              </MenuItem>
+              <MenuItem value="glossary" key="glossary">
+                {DocumentHelper.transcriptionTypeLabels.glossary}
+              </MenuItem>
+            </Select>
+            <span
+              title="Toggle folio help"
+              onClick={toggleHelp}
+              className="helpIcon"
+            >
+              <i className="fas fa-question-circle" />
+            </span>
+            <HelpPopper
+              marginStyle={helpMarginStyle}
+              anchorEl={helpRef.current}
+              open={openHelp}
+              onClose={toggleHelp}
             />
-
           </div>
-        )
-          : (<AlphabetLinks onFilterChange={onFilterChange} value={props.value} />)}
 
-        <div id="doc-type-help" style={selectContainerStyle} ref={e => { helpRef.current = e; }}>
-          <Select
-            className={selectClass}
-            style={{ ...selectColorStyle, marginRight: 15 }}
-            value={documentView[side].transcriptionType}
-            id="doc-type"
-            onClick={changeType}
-          >
-            {Object.keys(props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).annotationURLs).map(ttKey => (
-              <MenuItem value={ttKey} key={ttKey}>{props.document.variorum ? props.document.transcriptionTypes[props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).doc_id][ttKey] : props.document.transcriptionTypes[ttKey]}</MenuItem>
-            ))}
-            <MenuItem value="f" key="f">
-              {DocumentHelper.transcriptionTypeLabels.f}
-            </MenuItem>
-            <MenuItem value="glossary" key="glossary">
-              {DocumentHelper.transcriptionTypeLabels.glossary}
-            </MenuItem>
-          </Select>
-          <span
-            title="Toggle folio help"
-            onClick={toggleHelp}
-            className="helpIcon"
-          >
-            <i className="fas fa-question-circle" />
-          </span>
-          <HelpPopper
-            marginStyle={helpMarginStyle}
-            anchorEl={helpRef.current}
-            open={openHelp}
-            onClose={toggleHelp}
-          />
         </div>
-
       </div>
-    </div>
+      <div className="navigationComponentNarrow">
+        <div id="navigation-row" className="navigationRowNarrow">
+
+          { documentView[side].transcriptionType !== 'glossary' ? (
+
+            <div id="tool-bar-buttons" className="breadcrumbsNarrow" style={showButtonsStyle}>
+                
+              <span 
+                className="fas fa-th" 
+                style={{ cursor: documentView[side].transcriptionType !== 'g' ? 'pointer' : 'default', padding: '0 15px' }} 
+                title={documentView[side].transcriptionType !== 'g' && "Return to Grid View"} 
+                onClick={documentView[side].transcriptionType !== 'g' && onGoToGrid} 
+              />
+                                                &nbsp;
+              <span
+                title="Toggle XML mode"
+                onClick={toggleXMLMode}
+                className={imageViewActive ? 'invisible' : xmlIconClass}
+              />
+
+            </div>
+          )
+            : (<AlphabetLinks onFilterChange={onFilterChange} value={props.value} />)}
+
+          <div id="doc-type-help" style={selectContainerStyle} ref={e => { helpRef.current = e; }}>
+            <Select
+              className={selectClass}
+              style={{ ...selectColorStyle, marginRight: 15 }}
+              value={documentView[side].transcriptionType}
+              id="doc-type"
+              onClick={changeType}
+            >
+              {Object.keys(props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).annotationURLs).map(ttKey => (
+                <MenuItem value={ttKey} key={ttKey}>{props.document.variorum ? props.document.transcriptionTypes[props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).doc_id][ttKey] : props.document.transcriptionTypes[ttKey]}</MenuItem>
+              ))}
+              <MenuItem value="f" key="f">
+                {DocumentHelper.transcriptionTypeLabels.f}
+              </MenuItem>
+              <MenuItem value="glossary" key="glossary">
+                {DocumentHelper.transcriptionTypeLabels.glossary}
+              </MenuItem>
+            </Select>
+            <span
+              title="Toggle folio help"
+              onClick={toggleHelp}
+              className="helpIcon"
+            >
+              <i className="fas fa-question-circle" />
+            </span>
+            <HelpPopper
+              marginStyle={helpMarginStyle}
+              anchorEl={helpRef.current}
+              open={openHelp}
+              onClose={toggleHelp}
+            />
+          </div>
+
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/editioncrafter/src/component/RingSpinner.js
+++ b/editioncrafter/src/component/RingSpinner.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+// create an inline spinner (uses Pure CSS Loaders: https://loading.io/css/)
+export function InlineRingSpinner(foregroundColor) {
+    // color can be 'light' or 'dark'
+    return <div className="inline-ring-spinner"><div className={foregroundColor}></div><div></div><div></div><div></div></div>
+}
+
+export function BigRingSpinner() {
+    return <div className="big-ring-spinner"><div></div><div></div><div></div><div></div></div>
+}

--- a/editioncrafter/src/component/RingSpinner.js
+++ b/editioncrafter/src/component/RingSpinner.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 // create an inline spinner (uses Pure CSS Loaders: https://loading.io/css/)
 export function InlineRingSpinner(foregroundColor) {
@@ -6,6 +6,17 @@ export function InlineRingSpinner(foregroundColor) {
     return <div className="inline-ring-spinner"><div className={foregroundColor}></div><div></div><div></div><div></div></div>
 }
 
-export function BigRingSpinner() {
-    return <div className="big-ring-spinner"><div></div><div></div><div></div><div></div></div>
+export function BigRingSpinner(props) {
+    const { delay = 0, color = 'dark' } = props;
+    const [show, setShow] = useState(delay === 0);
+
+    useEffect(() => {
+        if (delay > 0) {
+            setTimeout(() => {
+                setShow(true)
+            }, delay);
+        }
+    }, []);
+
+    return show ? <div className={`big-ring-spinner ${color}`}><div></div><div></div><div></div><div></div></div> : <div></div>
 }

--- a/editioncrafter/src/component/SeaDragonComponent.js
+++ b/editioncrafter/src/component/SeaDragonComponent.js
@@ -1,11 +1,15 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
+import { BigRingSpinner } from './RingSpinner';
 
 const SeaDragonComponent = (props) => {
   const { side, initViewer, tileSource } = props;
+  const [loading, setLoading] = useState(true);
 
   const viewer = useMemo(() => (
-    <div id={`image-view-seadragon-${side}`} ref={(el) => { initViewer(el, tileSource); }} />
-  ), []);
+    <div id={`image-view-seadragon-${side}`} ref={(el) => { initViewer(el, tileSource).then(() => {setLoading(false);}) }}>
+      { loading && <BigRingSpinner color="light" />}
+    </div>
+  ), [loading]);
 
   return viewer;
 };

--- a/editioncrafter/src/component/SinglePaneView.js
+++ b/editioncrafter/src/component/SinglePaneView.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-class SplitPaneView extends Component {
+class SinglePaneView extends Component {
   render() {
     return (
       <div className="single-pane-view">
@@ -16,4 +16,4 @@ function mapStateToProps(state) {
     document: state.document,
   };
 }
-export default connect(mapStateToProps)(SplitPaneView);
+export default connect(mapStateToProps)(SinglePaneView);

--- a/editioncrafter/src/component/TranscriptionView.js
+++ b/editioncrafter/src/component/TranscriptionView.js
@@ -7,6 +7,7 @@ import Parser from './Parser';
 import EditorComment from './EditorComment';
 import ErrorBoundary from './ErrorBoundary';
 import Watermark from './Watermark';
+import { BigRingSpinner } from './RingSpinner';
 
 const addZoneStyle = (selectedZone, domNode, facses) => {
   if (facses.includes(selectedZone)) {
@@ -94,6 +95,7 @@ const TranscriptionView = (props) => {
   } = props;
 
   if (folioID === '-1') {
+    console.log('no folio');
     return (
       <Watermark
         documentView={documentView}
@@ -104,7 +106,8 @@ const TranscriptionView = (props) => {
   }
 
   const folio = document.folioIndex[folioID];
-  if (!folio.transcription) {
+
+  if (folio && !folio.loading && !folio.transcription) {
     return (
       <Watermark
         documentView={documentView}
@@ -113,9 +116,10 @@ const TranscriptionView = (props) => {
       />
     );
   }
-  const transcriptionData = folio.transcription[transcriptionType];
+  const transcriptionData = folio && folio.transcription && folio.transcription[transcriptionType];
 
-  if (!transcriptionData) {
+  if (folio && !folio.loading && !transcriptionData) {
+    console.log('no transcription data');
     return (
       <Watermark
         documentView={documentView}
@@ -127,9 +131,11 @@ const TranscriptionView = (props) => {
 
   // Configure parser to replace certain tags with components
   const htmlToReactParserOptionsSide = htmlToReactParserOptions(searchParams.get('zone'));
-  const { html, layout } = transcriptionData;
+  const html = transcriptionData && transcriptionData.html;
+  const layout = transcriptionData && transcriptionData.layout;
 
-  if (!html) {
+  if (folio && !folio.loading && !html) {
+    console.log('no html');
     return (
       <Watermark
         documentView={documentView}
@@ -139,7 +145,32 @@ const TranscriptionView = (props) => {
     );
   }
 
-  const surfaceStyle = { gridTemplateAreas: layout };
+  if (folio && folio.loading) {
+    return (
+      <div>
+      <Navigation
+        side={side}
+        documentView={documentView}
+        documentViewActions={documentViewActions}
+        documentName={document.variorum && folio.doc_id}
+      />
+      <Pagination side={side} documentView={documentView} documentViewActions={documentViewActions} />
+      <div className="transcriptionViewComponent">
+        <div className="transcriptContent">
+          <ErrorBoundary>
+            <BigRingSpinner delay={3000} color="dark" />
+          </ErrorBoundary>
+        </div>
+      </div>
+
+      <Pagination
+        side={side}
+        documentView={documentView}
+        documentViewActions={documentViewActions}
+      />
+    </div>
+    )
+  }
 
   return (
     <div>
@@ -155,7 +186,7 @@ const TranscriptionView = (props) => {
           <ErrorBoundary>
             <div
               className="surface grid-mode"
-              style={surfaceStyle}
+              style={{gridTemplateAreas: layout}}
             >
               <Parser
                 html={html}

--- a/editioncrafter/src/scss/_diplomatic.scss
+++ b/editioncrafter/src/scss/_diplomatic.scss
@@ -1,4 +1,6 @@
 #diplomatic {
+	container-type: size;
+	container-name: diplomatic;
 	#content-view, .header-wrapper, #entry-list-view, #annotation-list-view {
 		h1,
 		h2,

--- a/editioncrafter/src/scss/_diplomatic.scss
+++ b/editioncrafter/src/scss/_diplomatic.scss
@@ -299,15 +299,16 @@
 
 #diplomatic.fixed {
 	background: white;
-	position: fixed;
-	width: 100vw;
-	height: calc(100vh - $chrome-height);
-	@include sm {
-		height: calc(100vh - $sm-chrome-height);
-	}
-	@include md {
-		height: calc(100vh - $md-chrome-height);
-	}
+	// position: fixed;
+	width: auto;
+	height: auto;
+	// height: calc(100% - $chrome-height);
+	// @include sm {
+	// 	height: calc(100% - $sm-chrome-height);
+	// }
+	// @include md {
+	// 	height: calc(100% - $md-chrome-height);
+	// }
 	font-size: 0.7rem;
 
 	-webkit-user-select: none;

--- a/editioncrafter/src/scss/_glossary.scss
+++ b/editioncrafter/src/scss/_glossary.scss
@@ -30,6 +30,11 @@
 			top: initial;
 		}
 	}
+
+	.navigationComponentNarrow {
+		position: sticky;
+		top: 0;
+	}
 	
 	.glossaryNav {
 

--- a/editioncrafter/src/scss/_navigation.scss
+++ b/editioncrafter/src/scss/_navigation.scss
@@ -61,6 +61,7 @@
 .navigationRowNarrow {
       display:flex;
       justify-content:space-between;
+      align-items: baseline;
       padding:6px 5px 6px 5px;
       @include md {
             display:none;
@@ -93,6 +94,14 @@
       }
 
 }
+
+.imageViewComponent .navigationComponentNarrow {
+      background-color: rgba(0,0,0,1);
+      color: #ffffff;
+      border-radius: 0;
+      opacity: 1;
+}
+
 .transcriptionViewComponent .navigationComponent {
 	background-color: rgba(255,255,255,1);;
 	color: #000000;

--- a/editioncrafter/src/scss/_navigation.scss
+++ b/editioncrafter/src/scss/_navigation.scss
@@ -34,7 +34,7 @@
 }
 
 .helpIcon {
-      display: none;
+      display: inline-block;
       margin-top:6px;
       margin-right:16px;
       @include md {

--- a/editioncrafter/src/scss/_navigation.scss
+++ b/editioncrafter/src/scss/_navigation.scss
@@ -3,6 +3,7 @@
             font-size: 15px;
       }
       position: fixed;
+      display: none;
       z-index: 2;
       height:48px;
 	white-space: nowrap;
@@ -11,7 +12,6 @@
 	-ms-user-select: none;
       user-select: none;
       padding:4px;
-      top: 75px;
       background-color: white;
       border-radius: 0.3rem;
       @include sm {
@@ -19,6 +19,30 @@
       }
       @include md {
             top: initial;
+            display: block;
+      }
+      button{
+            cursor: pointer;
+      }
+}
+
+.navigationComponentNarrow {
+      #tool-bar-buttons{
+            font-size: 15px;
+      }
+      display: block;
+      width: auto;
+      z-index: 2;
+	white-space: nowrap;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+      user-select: none;
+      padding:4px;
+      background-color: white;
+      @include md {
+            top: initial;
+            display: none;
       }
       button{
             cursor: pointer;
@@ -26,11 +50,21 @@
 }
 
 .navigationRow{
-      display:flex;
+      display:none;
       justify-content:space-between;
       padding:12px 10px 12px 10px;
-      
-      
+      @include md {
+            display:flex;
+      }     
+}
+
+.navigationRowNarrow {
+      display:flex;
+      justify-content:space-between;
+      padding:6px 5px 6px 5px;
+      @include md {
+            display:none;
+      } 
 }
 
 .helpIcon {
@@ -77,9 +111,17 @@
 
 .breadcrumbs {
       overflow:hidden;
-      display: none;
+      display: hidden;
       @include md {
             display: block;
+      }
+}
+
+.breadcrumbsNarrow {
+      overflow:hidden;
+      display: block;
+      @include md {
+            display: none;
       }
 }
 

--- a/editioncrafter/src/scss/_ringSpinner.scss
+++ b/editioncrafter/src/scss/_ringSpinner.scss
@@ -58,10 +58,16 @@
   width: 128px;
   height: 128px;
   margin-top: 30vh;
-  border: 16px solid #000;
   border-radius: 50%;
   animation: big-ring-spinner 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
-  border-color: #000 transparent transparent transparent;
+}
+.big-ring-spinner.dark div {
+    border: 16px solid #000;
+    border-color: #000 transparent transparent transparent;
+}
+.big-ring-spinner.light div {
+    border: 16px solid #fff;
+    border-color: #fff transparent transparent transparent;
 }
 .big-ring-spinner div:nth-child(1) {
   animation-delay: -0.45s;

--- a/editioncrafter/src/scss/_ringSpinner.scss
+++ b/editioncrafter/src/scss/_ringSpinner.scss
@@ -1,0 +1,82 @@
+/* Small inline spinner */
+.inline-ring-spinner {
+    display: inline-block;
+    margin-left: 10px;
+    margin-right: 10px;
+    width: 16px;
+    height: 16px;
+  }
+
+.inline-ring-spinner .light {
+  border: 3px solid #fff;
+  border-color: #fff transparent transparent transparent;
+}
+
+.inline-ring-spinner .dark {
+  border: 3px solid #000;
+  border-color: #000 transparent transparent transparent;
+}
+
+.inline-ring-spinner div {
+  box-sizing: border-box;
+  display: block;
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  animation: inline-ring-spinner 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+}
+.inline-ring-spinner div:nth-child(1) {
+  animation-delay: -0.45s;
+}
+.inline-ring-spinner div:nth-child(2) {
+  animation-delay: -0.3s;
+}
+.inline-ring-spinner div:nth-child(3) {
+  animation-delay: -0.15s;
+}
+@keyframes inline-ring-spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+/* Big spinner */
+.big-ring-spinner {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+}
+.big-ring-spinner div {
+  box-sizing: border-box;
+  display: block;
+  position: absolute;
+  width: 128px;
+  height: 128px;
+  margin-top: 30vh;
+  border: 16px solid #000;
+  border-radius: 50%;
+  animation: big-ring-spinner 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+  border-color: #000 transparent transparent transparent;
+}
+.big-ring-spinner div:nth-child(1) {
+  animation-delay: -0.45s;
+}
+.big-ring-spinner div:nth-child(2) {
+  animation-delay: -0.3s;
+}
+.big-ring-spinner div:nth-child(3) {
+  animation-delay: -0.15s;
+}
+@keyframes big-ring-spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/editioncrafter/src/scss/editioncrafter.scss
+++ b/editioncrafter/src/scss/editioncrafter.scss
@@ -56,27 +56,27 @@ animation: #{$str};
 
 // BREAKPOINT MIXINS
 @mixin xs {
-   @media (min-width: #{$screen-xs-min}) {
+   @container diplomatic (min-width: #{$screen-xs-min}) {
        @content;
    }
 }
 @mixin sm {
-   @media (min-width: #{$screen-sm-min}) {
+   @container diplomatic (min-width: #{$screen-sm-min}) {
        @content;
    }
 }
 @mixin md {
-   @media (min-width: #{$screen-md-min}) {
+   @container diplomatic (min-width: #{$screen-md-min}) {
        @content;
    }
 }
 @mixin lg {
-   @media (min-width: #{$screen-lg-min}) {
+   @container diplomatic (min-width: #{$screen-lg-min}) {
        @content;
    }
 }
 @mixin xl {
-   @media (min-width: #{$screen-xl-min}) {
+   @container diplomatic (min-width: #{$screen-xl-min}) {
        @content;
    }
 }

--- a/editioncrafter/src/scss/editioncrafter.scss
+++ b/editioncrafter/src/scss/editioncrafter.scss
@@ -107,3 +107,5 @@ animation: #{$str};
 @import "jumpbox";
 
 @import "CETEIcean";
+
+@import "ringSpinner"; 

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -80,6 +80,19 @@ export const MultiDocument = () => (
   />
 );
 
+export const embeddedDiv = () => (
+  <div style={{ width: '700px', margin: '0 auto' }}>
+    <EditionCrafter
+      documentName='FHL_007548733_TAOS_BAPTISMS_BATCH_2'
+      transcriptionTypes={{
+        translation: 'Translation',
+        transcription: 'Transcription',
+      }}
+      iiifManifest='https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json'
+    />
+  </div>
+)
+
 export default {
   title: 'EditionCrafter',
 };


### PR DESCRIPTION
### In this PR

This PR does two main things.
- Instead of having the viewer be set to 100vw and 100vh, it now defaults to filling the width of its container. The goal of this is to make it easier for developers to include the Edition Crafter viewer in their page layouts in a flexible and responsive way.
  - As part of this change, I also updated the CSS to not hide the dropdown menu and help icon when at narrow widths. However, that feature could still use some better styling; right now it just wraps around and displays on the left of the pane when the width is small.
- This PR also adds a simple loading spinner to both the transcription view and the image view. The caveat is that the loading spinner for the image view only appears while the OpenSeaDragon viewer is first mounting; if the actual image inside the viewer takes a few seconds to load, there will still be a blank screen. I'm not sure how to make that behave differently without diving into the OpenSeaDragon code.

### Further work
- As mentioned, there is still some refining of the layout on "mobile" or generally narrow widths. (For this it might be nice to know exactly what the desire layout is -- should the dropdown still be in the upper right? Should it be modified to be smaller or be hidden by default and revealed with some sort of little arrow or tab or something?)
- I have not yet added any sort of loading spinner to the Image Grid view.
- In general, this should be tested pretty robustly in various different layouts/sizes before this PR is merged; I'm sure there are some weird corner case layouts that I did not account for yet.