### PR TITLE
Improved navigation component styling

### DIFF
--- a/editioncrafter/src/component/GlossaryView.js
+++ b/editioncrafter/src/component/GlossaryView.js
@@ -94,7 +94,7 @@ class GlossaryView extends Component {
     if (!this.props.glossary.loaded) return null;
 
     return (
-      <div id="glossaryView">
+      <div id="glossaryView" style={{ position: "relative" }}>
         <Navigation
           side={this.props.side}
           onFilterChange={this.onFilterChange}

--- a/editioncrafter/src/component/ImageView.js
+++ b/editioncrafter/src/component/ImageView.js
@@ -148,7 +148,7 @@ const ImageView = (props) => {
     <div>
       { tileSource
       ? (
-      <div className={`image-view imageViewComponent ${props.side}`}>
+      <div className={`image-view imageViewComponent ${props.side}`} style={{ position: "relative" }}>
         <Navigation
           side={props.side}
           documentView={props.documentView}

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -189,68 +189,72 @@ const Navigation = (props) => {
           { documentView[side].transcriptionType !== 'glossary' ? (
 
             <div id="tool-bar-buttons" className="breadcrumbs" style={showButtonsStyle}>
+              <div style={{ display: 'flex', alignItems: 'baseline', gap: '2px' }}> 
+                <span 
+                  className="fas fa-th" 
+                  style={{ cursor: documentView[side].transcriptionType !== 'g' ? 'pointer' : 'default', padding: '0 15px' }} 
+                  title={documentView[side].transcriptionType !== 'g' && "Return to Grid View"} 
+                  onClick={documentView[side].transcriptionType !== 'g' && onGoToGrid} 
+                />
+
+                <span
+                  title="Toggle coordination of views"
+                  onClick={toggleLockmode}
+                  className={lockIconClass}
+                />
+                                          
+                <span
+                  title="Toggle book mode"
+                  onClick={toggleBookmode}
+                  className={bookIconClass}
+                />
+                                      
+                <span
+                  title="Toggle XML mode"
+                  onClick={toggleXMLMode}
+                  className={imageViewActive ? 'invisible' : xmlIconClass}
+                />
+                                              
+                {/* <span title="Toggle single column mode"  onClick={this.toggleColumns}
+                                                        className={columnIconClass}></span> */}
+                                              
                 
-              <span 
-                className="fas fa-th" 
-                style={{ cursor: documentView[side].transcriptionType !== 'g' ? 'pointer' : 'default', padding: '0 15px' }} 
-                title={documentView[side].transcriptionType !== 'g' && "Return to Grid View"} 
-                onClick={documentView[side].transcriptionType !== 'g' && onGoToGrid} 
-              />
+                <span
+                  title="Go back"
+                  onClick={changeCurrentFolio}
+                  data-id={documentView[side].previousFolioShortID}
+                  className={(documentView[side].hasPrevious) ? 'arrow' : 'arrow disabled'}
+                >
 
-              <span
-                title="Toggle coordination of views"
-                onClick={toggleLockmode}
-                className={lockIconClass}
-              />
-                                                &nbsp;
-              <span
-                title="Toggle book mode"
-                onClick={toggleBookmode}
-                className={bookIconClass}
-              />
-                                                &nbsp;
-              <span
-                title="Toggle XML mode"
-                onClick={toggleXMLMode}
-                className={imageViewActive ? 'invisible' : xmlIconClass}
-              />
-                                                &nbsp;
-              {/* <span title="Toggle single column mode"  onClick={this.toggleColumns}
-                                                      className={columnIconClass}></span> */}
-                                                &nbsp;
-              
-              <span
-                title="Go back"
-                onClick={changeCurrentFolio}
-                data-id={documentView[side].previousFolioShortID}
-                className={(documentView[side].hasPrevious) ? 'arrow' : 'arrow disabled'}
-              >
-                {' '}
-                <FaArrowCircleLeft />
-                {' '}
-              
-              </span>
+                  <FaArrowCircleLeft />
 
-              <span
-                title="Go forward"
-                onClick={changeCurrentFolio}
-                data-id={documentView[side].nextFolioShortID}
-                className={(documentView[side].hasNext) ? 'arrow' : 'arrow disabled'}
-              >
-                {' '}
-                <FaArrowCircleRight />
-              </span>
+                
+                </span>
+
+                <span
+                  title="Go forward"
+                  onClick={changeCurrentFolio}
+                  data-id={documentView[side].nextFolioShortID}
+                  className={(documentView[side].hasNext) ? 'arrow' : 'arrow disabled'}
+                >
+
+                  <FaArrowCircleRight />
+                </span>
+              </div>
                                                 &nbsp;&nbsp;
-              {props.documentName || document.documentName}
-              {' / '}
-              <div
-                onClick={revealJumpBox}
-                className="folioName"
-              >
-                {' '}
-                {folioName}
-                {' '}
-                <span style={jumpToIconStyle} className="fa fa-hand-point-right" />
+              <div title={`${props.documentName || document.documentName}/${folioName}`} style={{ display: 'flex', overflowX: 'hidden', justifyContent: 'flex-end' }}>
+                <span>{props.documentName || document.documentName}</span>
+                <span>{' / '}</span>
+                <div
+                  onClick={revealJumpBox}
+                  className="folioName"
+                  style={{ flexShrink: '0' }}
+                >
+
+                  {folioName}
+
+                  <span style={jumpToIconStyle} className="fa fa-hand-point-right" />
+                </div>
               </div>
 
               <JumpToFolio

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -161,6 +161,8 @@ const Navigation = (props) => {
     return null;
   };
 
+  console.log(side, documentView[side]);
+
   const recommendedWidth = (documentView[side].width - 8);// the divder is 16 px wide so each side is minus 8
   const widthStyle = { width: recommendedWidth, maxWidth: recommendedWidth };
   const selectColorStyle = documentView[side].transcriptionType === 'f' ? { color: 'white' } : { color: 'black' };
@@ -181,7 +183,7 @@ const Navigation = (props) => {
 
   return (
     <>
-      <div className="navigationComponent" style={widthStyle}>
+      <div className="navigationComponent">
         <div id="navigation-row" className="navigationRow">
 
           { documentView[side].transcriptionType !== 'glossary' ? (

--- a/editioncrafter/src/component/TranscriptionView.js
+++ b/editioncrafter/src/component/TranscriptionView.js
@@ -147,7 +147,7 @@ const TranscriptionView = (props) => {
 
   if (folio && folio.loading) {
     return (
-      <div>
+      <div style={{ position: "relative" }}>
       <Navigation
         side={side}
         documentView={documentView}
@@ -173,7 +173,7 @@ const TranscriptionView = (props) => {
   }
 
   return (
-    <div>
+    <div style={{ position: "relative" }}>
       <Navigation
         side={side}
         documentView={documentView}

--- a/editioncrafter/src/component/Watermark.js
+++ b/editioncrafter/src/component/Watermark.js
@@ -3,7 +3,7 @@ import Navigation from './Navigation';
 import Pagination from './Pagination';
 
 const Watermark = ({ side, documentView, documentViewActions }) => (
-  <div>
+  <div style={{ position: "relative" }}>
     { documentView.left.iiifShortID !== '-1' && documentView.right.iiifShortID !== '-1'
       ? <Navigation side={side} documentView={documentView} documentViewActions={documentViewActions} />
       : null}

--- a/editioncrafter/src/component/XMLView.js
+++ b/editioncrafter/src/component/XMLView.js
@@ -40,7 +40,7 @@ class XMLView extends Component {
     const { xml: xmlContent } = transcriptionData;
 
     return (
-      <div id={thisID} className={thisClass}>
+      <div id={thisID} className={thisClass} style={{ position: "relative" }}>
         <Navigation side={side} documentView={documentView} documentViewActions={documentViewActions} documentName={document.variorum && folio.doc_id}/>
         <Pagination side={side} className="pagination_upper" documentView={documentView} documentViewActions={documentViewActions} />
 

--- a/editioncrafter/src/scss/_navigation.scss
+++ b/editioncrafter/src/scss/_navigation.scss
@@ -2,10 +2,11 @@
       #tool-bar-buttons{
             font-size: 15px;
       }
-      position: fixed;
+      position: absolute;
       display: none;
       z-index: 2;
       height:48px;
+      width: 100%;
 	white-space: nowrap;
 	-webkit-user-select: none;
 	-moz-user-select: none;
@@ -18,8 +19,9 @@
             top: 80px;
       }
       @include md {
-            top: initial;
-            display: block;
+            top: 0;
+            left: 0;
+            display: flex;
       }
       button{
             cursor: pointer;
@@ -52,6 +54,9 @@
 .navigationRow{
       display:none;
       justify-content:space-between;
+      align-items:center;
+      gap: 10px;
+      width: 100%;
       padding:12px 10px 12px 10px;
       @include md {
             display:flex;
@@ -61,7 +66,9 @@
 .navigationRowNarrow {
       display:flex;
       justify-content:space-between;
-      align-items: baseline;
+      align-items: center;
+      gap: 10px;
+      width: 100%;
       padding:6px 5px 6px 5px;
       @include md {
             display:none;
@@ -119,16 +126,20 @@
 }
 
 .breadcrumbs {
-      overflow:hidden;
+      overflow-x:hidden;
       display: hidden;
+      align-items: baseline;
+      max-width: 68%;
       @include md {
-            display: block;
+            display: flex;
       }
 }
 
 .breadcrumbsNarrow {
-      overflow:hidden;
-      display: block;
+      overflow-x:hidden;
+      display: flex;
+      align-items: baseline;
+      max-width: 68%;
       @include md {
             display: none;
       }

--- a/editioncrafter/src/scss/_navigation.scss
+++ b/editioncrafter/src/scss/_navigation.scss
@@ -32,9 +32,11 @@
       #tool-bar-buttons{
             font-size: 15px;
       }
-      display: block;
+      display: flex;
       width: auto;
       z-index: 2;
+      height:48px;
+      width: 100%;
 	white-space: nowrap;
 	-webkit-user-select: none;
 	-moz-user-select: none;
@@ -43,7 +45,6 @@
       padding:4px;
       background-color: white;
       @include md {
-            top: initial;
             display: none;
       }
       button{
@@ -129,7 +130,7 @@
       overflow-x:hidden;
       display: hidden;
       align-items: baseline;
-      max-width: 68%;
+      max-width: 70%;
       @include md {
             display: flex;
       }
@@ -139,13 +140,13 @@
       overflow-x:hidden;
       display: flex;
       align-items: baseline;
-      max-width: 68%;
+      max-width: 70%;
       @include md {
             display: none;
       }
 }
 
-.breadcrumbs .folioName {
+.breadcrumbs .folioName, .breadcrumbsNarrow .folioName {
   display:inline;
   white-space: nowrap;
   overflow: hidden;

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -81,7 +81,7 @@ export const MultiDocument = () => (
 );
 
 export const embeddedDiv = () => (
-  <div style={{ width: '700px', margin: '0 auto' }}>
+  <div style={{ width: '1200px', margin: '0 auto' }}>
     <EditionCrafter
       documentName='FHL_007548733_TAOS_BAPTISMS_BATCH_2'
       transcriptionTypes={{


### PR DESCRIPTION
### In this PR
Tweaks the CSS of the `Navigation` component to make it adjust width appropriately to its container, rather than having the width hard-coded based on the overall screen size.
![image](https://github.com/cu-mkp/editioncrafter/assets/110847635/5c052a05-aa25-4a1c-95d9-1cb34f17199b)


