### PR TITLE
Updated editioncrafter version number in astro site

### DIFF
--- a/astro-web/package.json
+++ b/astro-web/package.json
@@ -14,7 +14,7 @@
     "@astrojs/mdx": "^2.1.1",
     "@astrojs/react": "^3.0.10",
     "@astrojs/tailwind": "^5.1.0",
-    "@cu-mkp/editioncrafter": "^0.2.3",
+    "@cu-mkp/editioncrafter": "^0.2.4",
     "@fontsource/dm-sans": "^5.0.19",
     "@fontsource/martel": "^5.0.12",
     "@fontsource/source-code-pro": "^5.0.17",


### PR DESCRIPTION
### In this PR
Updated the Astro site to use the latest NPM release (v0.2.4).