### PR TITLE
Fixing navigation behavior on scroll

### DIFF
--- a/editioncrafter-umd/package.json
+++ b/editioncrafter-umd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cu-mkp/editioncrafter-umd",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "homepage": "https://cu-mkp.github.io/editioncrafter/",
   "description": "A simple digital critical edition publication tool",
   "private": false,

--- a/editioncrafter/package.json
+++ b/editioncrafter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cu-mkp/editioncrafter",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "A simple digital critical edition publication tool",
   "homepage": "https://cu-mkp.github.io/editioncrafter/",
   "private": false,

--- a/editioncrafter/src/component/SplitPaneView.js
+++ b/editioncrafter/src/component/SplitPaneView.js
@@ -20,7 +20,7 @@ class SplitPaneView extends Component {
     const split_third = 1 - split_left - split_right;
     this.state = {
       style: {
-        gridTemplateColumns: `${split_left}fr ${this.dividerWidth}px ${split_right}fr ${this.dividerWidth}px ${split_third}fr`,
+        gridTemplateColumns: `${this.splitFraction}fr ${this.dividerWidth}px ${1 - this.splitFraction - this.splitFractionRight}fr ${this.dividerWidth}px ${this.splitFractionRight}fr`,
       },
     };
 
@@ -55,6 +55,7 @@ class SplitPaneView extends Component {
       if (left_viewWidth >= this.leftPaneMinWidth
         && right_viewWidth >= this.rightPaneMinWidth
         && third_viewWidth >= this.thirdPaneMinWidth) {
+        console.log(whole, left_viewWidth, third_viewWidth);
         this.splitFraction = (whole === 0) ? 0.0 : left_viewWidth / whole;
         this.splitFractionRight = (whole === 0) ? 0.0 : third_viewWidth / whole;
         this.updateUI();

--- a/editioncrafter/src/scss/_imageView.scss
+++ b/editioncrafter/src/scss/_imageView.scss
@@ -18,6 +18,10 @@
 		max-height: 100dvh;
 	}
 
+.imageViewComponent .navigationComponent {
+	position: absolute;
+}
+
 .a9s-annotation.a9s-annotation.selected > rect,
 .a9s-annotation.a9s-annotation.selected > polygon
  {

--- a/editioncrafter/src/scss/_navigation.scss
+++ b/editioncrafter/src/scss/_navigation.scss
@@ -2,7 +2,7 @@
       #tool-bar-buttons{
             font-size: 15px;
       }
-      position: absolute;
+      position: sticky;
       display: none;
       z-index: 2;
       height:48px;


### PR DESCRIPTION
### In this PR
- Updates the navigation bar to `position: sticky` on non-image panels, so that when there is vertical scroll the navigation won't be scrolled off the top.
- Updates the version number to 0.2.10 for new release.