### PR TITLE
Fixing watermark pane width and glossary scroll

### DIFF
--- a/editioncrafter-umd/package.json
+++ b/editioncrafter-umd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cu-mkp/editioncrafter-umd",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "homepage": "https://cu-mkp.github.io/editioncrafter/",
   "description": "A simple digital critical edition publication tool",
   "private": false,

--- a/editioncrafter/package.json
+++ b/editioncrafter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cu-mkp/editioncrafter",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "A simple digital critical edition publication tool",
   "homepage": "https://cu-mkp.github.io/editioncrafter/",
   "private": false,

--- a/editioncrafter/src/component/Watermark.js
+++ b/editioncrafter/src/component/Watermark.js
@@ -3,7 +3,7 @@ import Navigation from './Navigation';
 import Pagination from './Pagination';
 
 const Watermark = ({ side, documentView, documentViewActions }) => (
-  <div style={{ position: "relative" }}>
+  <div style={{ position: "relative" }} className="watermarkContainer">
     { documentView.left.iiifShortID !== '-1' && documentView.right.iiifShortID !== '-1'
       ? <Navigation side={side} documentView={documentView} documentViewActions={documentViewActions} />
       : null}

--- a/editioncrafter/src/scss/_glossary.scss
+++ b/editioncrafter/src/scss/_glossary.scss
@@ -1,7 +1,6 @@
 #glossaryView {
 
 	#glossaryViewInner {
-		overflow-y: scroll;
 		margin: 5px 0 0 0;
 		@include md {
 			margin: 52px 0 0 0;

--- a/editioncrafter/src/scss/_watermark.scss
+++ b/editioncrafter/src/scss/_watermark.scss
@@ -1,12 +1,16 @@
 $watermark-size: max(10rem, 160px);
 
+.watermarkContainer .navigationComponent {
+	position: absolute;
+}
+
 .watermark{
 	width:100%;
 	height:100%;
-	margin: calc(50vh - (#{$watermark-size}/2)) auto 0 auto;
+	margin: calc(50% - (#{$watermark-size}/2)) auto 0 auto;
 }
 .transcriptContent .watermark{
-   margin: calc(50vh - (25rem/2)) auto 0 auto;
+   margin: calc(50% - (25rem/2)) auto 0 auto;
 }
 
 .watermark_contents{


### PR DESCRIPTION
### In this PR
- Fixes a bug with pane resizing in the case that one of the panes is blank (watermark component), by making the navigation bar `position: absolute` in that case (rather than `sticky`).
- Fixes the way vertical overflow is handled in the glossary view to avoid triple scrollbar behavior in some contexts.
- Update version number to 0.2.11 in preparation for new release.