### PR TITLE
Another round of styling tweaks

### DIFF
--- a/editioncrafter-umd/package.json
+++ b/editioncrafter-umd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cu-mkp/editioncrafter-umd",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "homepage": "https://cu-mkp.github.io/editioncrafter/",
   "description": "A simple digital critical edition publication tool",
   "private": false,

--- a/editioncrafter/package.json
+++ b/editioncrafter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cu-mkp/editioncrafter",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "A simple digital critical edition publication tool",
   "homepage": "https://cu-mkp.github.io/editioncrafter/",
   "private": false,

--- a/editioncrafter/src/component/ImageGridView.js
+++ b/editioncrafter/src/component/ImageGridView.js
@@ -98,7 +98,10 @@ class ImageGridView extends React.Component {
   }
 
   onSelectDoc = (event) => {
-    if (event.target.value !== 'none') {
+    if (!event.target.value || event.target.value == 0) {
+      return;
+    }
+    if (event.target.value && event.target.value !== 'none') {
       this.setState({ ...this.state, currentDoc: event.target.value });
     } else {
       this.setState({ ...this.state, currentDoc: null });

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -358,9 +358,9 @@ const Navigation = (props) => {
               <MenuItem value="f" key="f">
                 {DocumentHelper.transcriptionTypeLabels.f}
               </MenuItem>
-              <MenuItem value="glossary" key="glossary">
+              { props.glossary && <MenuItem value="glossary" key="glossary">
                 {DocumentHelper.transcriptionTypeLabels.glossary}
-              </MenuItem>
+              </MenuItem> }
             </Select>
             <span
               title="Toggle folio help"

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -29,7 +29,7 @@ const Navigation = (props) => {
   };
 
   const changeType = (event) => {
-    if (event.target.value === undefined) return;
+    if (event.target.value === undefined || event.target.value === 0) return;
     props.documentViewActions.changeTranscriptionType(
       props.side,
       event.target.value,
@@ -353,7 +353,7 @@ const Navigation = (props) => {
               onClick={changeType}
             >
               {Object.keys(props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).annotationURLs).map(ttKey => (
-                <MenuItem value={ttKey} key={ttKey}>{props.document.variorum ? props.document.transcriptionTypes[props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).doc_id][ttKey] : props.document.transcriptionTypes[ttKey]}</MenuItem>
+                <MenuItem value={ttKey} key={ttKey} title={ttKey}>{props.document.variorum ? props.document.transcriptionTypes[props.document.folios.find((fol) => (fol.id == props.documentView[props.side].iiifShortID)).doc_id][ttKey] : props.document.transcriptionTypes[ttKey]}</MenuItem>
               ))}
               <MenuItem value="f" key="f">
                 {DocumentHelper.transcriptionTypeLabels.f}

--- a/editioncrafter/src/scss/_imageGridView.scss
+++ b/editioncrafter/src/scss/_imageGridView.scss
@@ -6,6 +6,11 @@
 	max-height: 100dvh;
 }
 
+.imageGridComponent .thumbnail {
+	background-color: inherit;
+	border: none;
+}
+
 .imageGridComponent > ul {
 	display: flex;
 	flex-wrap: wrap;

--- a/editioncrafter/src/scss/_singlePaneView.scss
+++ b/editioncrafter/src/scss/_singlePaneView.scss
@@ -1,0 +1,9 @@
+.single-pane-view {
+    height: 100%;
+    width: 100%;
+    overflow: auto;
+}
+
+.single-pane-view > div {
+    height: 100%;
+}

--- a/editioncrafter/src/scss/editioncrafter.scss
+++ b/editioncrafter/src/scss/editioncrafter.scss
@@ -109,3 +109,4 @@ animation: #{$str};
 @import "CETEIcean";
 
 @import "ringSpinner"; 
+@import "singlePaneView";


### PR DESCRIPTION
### In this PR
- Fixes issue with facsimiles not displaying in single pane mode, by ensuring that all of the containing divs are set to `height: 100%` so it doesn't collapse to zero height;
- Removes the `Glossary` option from the mobile navigation menu when no glossary provided;
- Adds scroll to single pane mode in the case of vertical overflow;
- Fixes a bug with the dropdown menus where clicking on the current value would cause the value to become unset;
- Adds styling to the thumbnails on `ImageGridView` to override global styles in the case that the component is embedded on a site that sets thumbnail styles globally, e.g. the Scalar sites;
- Updates the version number to v0.2.12 in preparation for new release.