### PR TITLE
CSS tweaks and version update (1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![DOI](https://zenodo.org/badge/574677398.svg)](https://zenodo.org/badge/latestdoi/574677398)
 
 # editioncrafter
-NOW IN BETA: Software for the development of EditionCrafter, digital critical edition publication tool
+Software for the development of EditionCrafter, digital critical edition publication tool
 
 EditionCrafter can be included in a React app or a HTML website. EditionCrafter should work on any content management system (CMS) where you can edit the HTML of your page. We have tested it on Hugo CMS, Astro Framework, and Scalar CMS. We also have an example Hugo website that you can fork. Please see that website's [README](https://github.com/cu-mkp/editioncrafter-project) for more information.
 

--- a/astro-web/src/components/Button.astro
+++ b/astro-web/src/components/Button.astro
@@ -6,7 +6,7 @@ export interface Props {
 
 const { light, href } = Astro.props
 
-const className = `inline-flex center items-center justify-center rounded-full pr-4 pl-4 lg:pl-6 lg:pr-6 py-3 text-sm font-semibold transition ${ light ? 'bg-white text-neutral-dark hover:bg-neutral' : 'bg-neutral-dark text-white hover:bg-neutral-gray'}`;
+const className = `inline-flex center items-center justify-center rounded-full pr-3 pl-3 md:pr-4 md:pl-4 lg:pl-6 lg:pr-6 py-3 text-sm font-semibold transition ${ light ? 'bg-white text-neutral-dark hover:bg-neutral' : 'bg-neutral-dark text-white hover:bg-neutral-gray'}`;
 
 ---
 <a href={ href || '#' }>

--- a/astro-web/src/components/Container.astro
+++ b/astro-web/src/components/Container.astro
@@ -6,7 +6,7 @@ const { className } = Astro.props;
 ---
 
 <div
-    class={clsx('mx-6 md:mx-16 lg:mx-16 xl:mx-auto max-w-screen-xl', className)}
+    class={clsx('mx-6 md:mx-16 xl:mx-24 2xl:mx-auto max-w-screen-xl', className)}
 >
 <slot />
 </div>

--- a/astro-web/src/components/Header.astro
+++ b/astro-web/src/components/Header.astro
@@ -17,7 +17,7 @@ const { tab } = Astro.props;
             <Image src={logo} alt="EditionCrafter" />
             <p class="text-2xl font-serif max-w-28 self-center">Edition Crafter</p>
         </a>
-        <div class="flex flex-row gap-8 align-middle">
+        <div class="sm:flex flex-row gap-8 align-middle hidden">
 			<Button light href='/editioncrafter/getting-started'>
 				Getting Started
 			</Button>

--- a/astro-web/src/layouts/Docs.astro
+++ b/astro-web/src/layouts/Docs.astro
@@ -17,7 +17,7 @@ const { frontmatter } = Astro.props;
     </div>
 
     <div class="bg-white w-full relative">
-        <div class="inline-block lg:float-end py-4 lg:py-8 xl:py-12 lg:w-[66%] xl:w-[70%] 2xl:w-[78%] mx-auto px-6 md:px-16 lg:ps-4 lg:pe-16 2xl:pe-40 3xl:pe-64">
+        <div class="lg:inline-block lg:float-end py-4 lg:py-8 xl:py-12 lg:w-[66%] xl:w-[70%] 2xl:w-[78%] mx-auto px-6 md:px-16 lg:ps-4 lg:pe-16 2xl:pe-40 3xl:pe-64">
             <div class="w-full prose h-full max-w-none lg:float-end">
                 <slot />
             </div>

--- a/editioncrafter-umd/README.md
+++ b/editioncrafter-umd/README.md
@@ -1,7 +1,7 @@
 [![DOI](https://zenodo.org/badge/574677398.svg)](https://zenodo.org/badge/latestdoi/574677398)
 
 # editioncrafter
-NOW IN BETA: Software for the development of EditionCrafter, digital critical edition publication tool
+Software for the development of EditionCrafter, digital critical edition publication tool
 
 EditionCrafter can be included in a React app or a HTML website. EditionCrafter should work on any content management system (CMS) where you can edit the HTML of your page. We have tested it on Hugo CMS, Astro Framework, and Scalar CMS. We also have an example Hugo website that you can fork. Please see that website's [README](https://github.com/cu-mkp/editioncrafter-project) for more information.
 

--- a/editioncrafter-umd/package.json
+++ b/editioncrafter-umd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cu-mkp/editioncrafter-umd",
-  "version": "0.2.12",
+  "version": "1.0",
   "homepage": "https://cu-mkp.github.io/editioncrafter/",
   "description": "A simple digital critical edition publication tool",
   "private": false,

--- a/editioncrafter/README.md
+++ b/editioncrafter/README.md
@@ -1,7 +1,7 @@
 [![DOI](https://zenodo.org/badge/574677398.svg)](https://zenodo.org/badge/latestdoi/574677398)
 
 # editioncrafter
-NOW IN BETA: Software for the development of EditionCrafter, digital critical edition publication tool
+Software for the development of EditionCrafter, digital critical edition publication tool
 
 EditionCrafter can be included in a React app or a HTML website. EditionCrafter should work on any content management system (CMS) where you can edit the HTML of your page. We have tested it on Hugo CMS, Astro Framework, and Scalar CMS. We also have an example Hugo website that you can fork. Please see that website's [README](https://github.com/cu-mkp/editioncrafter-project) for more information.
 

--- a/editioncrafter/package.json
+++ b/editioncrafter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cu-mkp/editioncrafter",
-  "version": "0.2.12",
+  "version": "1.0",
   "description": "A simple digital critical edition publication tool",
   "homepage": "https://cu-mkp.github.io/editioncrafter/",
   "private": false,


### PR DESCRIPTION
### In this PR
- Smooths out the transitions between breakpoints for the CSS container element, and fixes some weird behavior of the documentation page at small screen width;
- Updates the version number to 1.0 for soft launch, and removes "NOW IN BETA" from the README files.