### PR TITLE
Improved variorum navigation and fixed folio name collision bug

### DIFF
--- a/editioncrafter/src/action/DocumentActions.js
+++ b/editioncrafter/src/action/DocumentActions.js
@@ -160,7 +160,7 @@ function parseSingleManifest(manifest, transcriptionTypes, document) {
       const thumbnailURL = `${bodyId}/full/${thumbnailDimensions.join(',')}/0/default.jpg`;
   
       const folio = {
-        id: folioID,
+        id: document ? `${document}_${folioID}` : folioID,
         doc_id: document || manifest.id,
         name: canvasLabel,
         pageNumber: i,

--- a/editioncrafter/src/component/DocumentView.js
+++ b/editioncrafter/src/component/DocumentView.js
@@ -368,6 +368,7 @@ const DocumentView = (props) => {
       hasNext: current_hasNext,
       previousFolioShortID: prevID,
       nextFolioShortID: nextID,
+      documentID: doc.variorum ? doc.folioIndex[shortID].doc_id : doc.documentName,
     };
   };
 
@@ -384,6 +385,7 @@ const DocumentView = (props) => {
     const viewType = determineViewType(side);
     const key = viewPaneKey(side);
     const folioID = docView[side].iiifShortID;
+    const document = docView[side].documentID;
     const { transcriptionType } = docView[side];
 
     if (viewType === 'ImageView') {
@@ -425,7 +427,7 @@ const DocumentView = (props) => {
           documentView={docView}
           documentViewActions={documentViewActions}
           side={side}
-          selectedDoc={props.document.variorum && Object.keys(props.document.derivativeNames)[side === 'left' ? 0 : side === 'right' ? 1 : Object.keys(props.document.derivativeNames).length > 2 ? 2 : 1]}
+          selectedDoc={document ? document : props.document.variorum && Object.keys(props.document.derivativeNames)[side === 'left' ? 0 : side === 'right' ? 1 : Object.keys(props.document.derivativeNames).length > 2 ? 2 : 1]}
         />
       );
     } if (viewType === 'GlossaryView') {


### PR DESCRIPTION
### In this PR
- Fixes bug in variorum mode where folios in different documents with the same `folioID` were not being stored properly in the component state: when in variorum mode, folios are now stored internally with the ID `[documentID]_[folioID]` to avoid collisions;
- Updates the `viewportState` function to track the associated document of the currently selected folio, so that if you navigate back to the grid view from a folio in variorum mode, the document that folio came from will be automatically selected.