### PR TITLE
Add support for plain images

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,42 @@
 {
-    "editor.formatOnSave": false
+  // Disable the default formatter, use eslint instead
+  "prettier.enable": false,
+  "editor.formatOnSave": false,
+
+  // Auto fix
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "never"
+  },
+
+  // Silent the stylistic rules in your IDE, but still auto fix them
+  "eslint.rules.customizations": [
+    { "rule": "style/*", "severity": "off", "fixable": true },
+    { "rule": "format/*", "severity": "off", "fixable": true },
+    { "rule": "*-indent", "severity": "off", "fixable": true },
+    { "rule": "*-spacing", "severity": "off", "fixable": true },
+    { "rule": "*-spaces", "severity": "off", "fixable": true },
+    { "rule": "*-order", "severity": "off", "fixable": true },
+    { "rule": "*-dangle", "severity": "off", "fixable": true },
+    { "rule": "*-newline", "severity": "off", "fixable": true },
+    { "rule": "*quotes", "severity": "off", "fixable": true },
+    { "rule": "*semi", "severity": "off", "fixable": true }
+  ],
+
+  // Enable eslint for all supported languages
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "vue",
+    "html",
+    "markdown",
+    "astro",
+    "css",
+    "less",
+    "scss",
+    "pcss",
+    "postcss"
+  ]
 }

--- a/editioncrafter/src/component/DiploMatic.js
+++ b/editioncrafter/src/component/DiploMatic.js
@@ -12,7 +12,7 @@ import RouteListener from './RouteListener';
 const DiploMatic = (props) => {
   const [containerWidth, setContainerWidth] = useState(0);
   const [containerHeight, setContainerHeight] = useState('min(100%, 100dvh');
-  const containerRef = useRef(null)
+  const containerRef = useRef(null);
   useEffect(() => {
     const history = createBrowserHistory();
     history.listen(() => {
@@ -21,9 +21,9 @@ const DiploMatic = (props) => {
   }, []);
 
   useEffect(() => {
-    if(containerRef.current){ 
-      setContainerWidth(containerRef.current.offsetWidth);  
-      if (containerRef.current.clientHeight == 0) {
+    if (containerRef.current) {
+      setContainerWidth(containerRef.current.offsetWidth);
+      if (containerRef.current.clientHeight === 0) {
         setContainerHeight('100dvh');
       }
     }

--- a/editioncrafter/src/component/DocumentView.js
+++ b/editioncrafter/src/component/DocumentView.js
@@ -30,7 +30,7 @@ const DocumentView = (props) => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  //"reload" the page if the config props change
+  // "reload" the page if the config props change
   useEffect(() => {
     dispatchAction(props, 'RouteListenerSaga.userNavigatation', location);
   }, [props.config]);
@@ -46,7 +46,7 @@ const DocumentView = (props) => {
 
   const getViewports = () => {
     const {
-      folioID, transcriptionType, folioID2, transcriptionType2, folioID3, transcriptionType3
+      folioID, transcriptionType, folioID2, transcriptionType2, folioID3, transcriptionType3,
     } = params;
     const { document } = props;
     const firstTranscriptionType = document.variorum ? Object.keys(document.transcriptionTypes[Object.keys(document.transcriptionTypes)[0]])[0] : Object.keys(document.transcriptionTypes)[0];
@@ -64,7 +64,7 @@ const DocumentView = (props) => {
         third: {
           folioID: '-1',
           transcriptionType: 'g',
-        }
+        },
       };
     }
     const leftFolioValid = Object.keys(document.folioIndex).includes(folioID);
@@ -76,12 +76,12 @@ const DocumentView = (props) => {
       const rightFolioValid = Object.keys(document.folioIndex).includes(folioID2);
       leftTranscriptionType = leftFolioValid ? transcriptionType : 'g';
       rightFolioID = rightFolioValid ? folioID2 : '-1';
-      rightTranscriptionType = rightFolioValid ? transcriptionType2 ? transcriptionType2 : firstTranscriptionType : 'g';
+      rightTranscriptionType = rightFolioValid ? transcriptionType2 || firstTranscriptionType : 'g';
       if (folioID3) {
         // route /ec/:folioID/:transcriptionType/:folioID2/:transcriptionType2/:folioID3/:transcriptionType3
         const thirdFolioValid = Object.keys(document.folioIndex).includes(folioID3);
         thirdFolioID = thirdFolioValid ? folioID3 : '-1';
-        thirdTranscriptionType = thirdFolioValid ? transcriptionType3 ? transcriptionType3 : firstTranscriptionType : 'g';
+        thirdTranscriptionType = thirdFolioValid ? transcriptionType3 || firstTranscriptionType : 'g';
       } else {
         thirdFolioID = '-1';
         thirdTranscriptionType = 'g';
@@ -91,7 +91,7 @@ const DocumentView = (props) => {
       // route /ec/:folioID/:transcriptionType
       leftTranscriptionType = 'f';
       rightFolioID = leftFolioValid ? folioID : '-1';
-      rightTranscriptionType = leftFolioValid ? transcriptionType ? transcriptionType : firstTranscriptionType : 'g';
+      rightTranscriptionType = leftFolioValid ? transcriptionType || firstTranscriptionType : 'g';
       thirdFolioID = '-1';
       thirdTranscriptionType = 'g';
     }
@@ -108,7 +108,7 @@ const DocumentView = (props) => {
       third: {
         folioID: thirdFolioID,
         transcriptionType: thirdTranscriptionType,
-      }
+      },
     };
   };
 
@@ -156,7 +156,11 @@ const DocumentView = (props) => {
       return [documentFolios[pageNumber - 1].id, documentFolios[pageNumber].id];
     }
 
-    return [documentFolios[pageNumber].id, documentFolios[pageNumber + 1].id];
+    if (documentFolios[pageNumber + 1]) {
+      return [documentFolios[pageNumber].id, documentFolios[pageNumber + 1].id];
+    }
+
+    return [documentFolios[pageNumber].id, null];
   };
 
   const onWidth = (leftWidth, rightWidth, thirdWidth) => {
@@ -198,7 +202,7 @@ const DocumentView = (props) => {
         currentViewports.right.transcriptionType,
         folioID,
         transcriptionType,
-      )
+      );
     }
   };
 
@@ -270,8 +274,8 @@ const DocumentView = (props) => {
           currentViewports.right.folioID,
           currentViewports.right.transcriptionType,
           folioID,
-          transcriptionType
-        )
+          transcriptionType,
+        );
       }
     } else if (side === 'left') {
       const otherSide = currentViewports.right;
@@ -302,8 +306,8 @@ const DocumentView = (props) => {
         currentViewports.right.folioID,
         currentViewports.right.transcriptionType,
         folioID,
-        transcriptionType
-      )
+        transcriptionType,
+      );
     }
   };
 
@@ -434,7 +438,7 @@ const DocumentView = (props) => {
           documentView={docView}
           documentViewActions={documentViewActions}
           side={side}
-          selectedDoc={document ? document : props.document.variorum && Object.keys(props.document.derivativeNames)[side === 'left' ? 0 : side === 'right' ? 1 : Object.keys(props.document.derivativeNames).length > 2 ? 2 : 1]}
+          selectedDoc={document || props.document.variorum && Object.keys(props.document.derivativeNames)[side === 'left' ? 0 : side === 'right' ? 1 : Object.keys(props.document.derivativeNames).length > 2 ? 2 : 1]}
         />
       );
     } if (viewType === 'GlossaryView') {
@@ -456,8 +460,8 @@ const DocumentView = (props) => {
     const pane = side === 'left'
       ? left
       : side === 'right'
-      ? right
-      : third;
+        ? right
+        : third;
 
     if (pane.viewType === 'ImageGridView') {
       return `${side}-${pane.viewType}`;
@@ -502,7 +506,7 @@ const DocumentView = (props) => {
   return (
     <div style={{ height: '100%' }}>
       <SinglePaneView
-        singlePane={renderPane(viewportState('left').iiifShortID === "-1" ? 'left' : 'right', docView)}
+        singlePane={renderPane(viewportState('left').iiifShortID === '-1' ? 'left' : 'right', docView)}
       />
     </div>
   );
@@ -511,7 +515,7 @@ const DocumentView = (props) => {
 function mapStateToProps(state) {
   return {
     document: state.document,
-    glossary: state.glossary
+    glossary: state.glossary,
   };
 }
 

--- a/editioncrafter/src/component/ImageGridView.js
+++ b/editioncrafter/src/component/ImageGridView.js
@@ -80,7 +80,7 @@ class ImageGridView extends React.Component {
   // in the case of a variorum, allow for filtering by document
   renderDocSelect() {
     return (
-      <div className='doc-select'>
+      <div className="doc-select">
         <Select
           id="doc-filter"
           className="dark"
@@ -138,8 +138,8 @@ class ImageGridView extends React.Component {
     const thumbs = folios.map((folio, index) => (
       // eslint-disable-next-line react/no-array-index-key
       <li key={`thumb-${index}`} className="thumbnail">
-        <figure><a id={folio.id} onClick={this.onClickThumb.bind(this, folio.id)}><img src={folio.image_thumbnail_url} alt={folio.name} style={{maxWidth: "130px", maxHeight: "130px"}} onError={({ currentTarget }) => {currentTarget.onerror = null; if (folio.image_zoom_url && currentTarget.src !== `${folio.image_zoom_url.slice(0, -9)}full/full/0/default.jpg`) {currentTarget.src=`${folio.image_zoom_url.slice(0, -9)}full/full/0/default.jpg`;} }} /></a></figure>
-        <figcaption className='thumbnail-caption'>
+        <figure><a id={folio.id} onClick={this.onClickThumb.bind(this, folio.id)}><img src={folio.image_thumbnail_url} alt={folio.name} style={{ maxWidth: '130px', maxHeight: '130px' }} onError={({ currentTarget }) => { currentTarget.onerror = null; if (folio.image_zoom_url && currentTarget.src !== `${folio.image_zoom_url.slice(0, -9)}full/full/0/default.jpg`) { currentTarget.src = `${folio.image_zoom_url.slice(0, -9)}full/full/0/default.jpg`; } }} /></a></figure>
+        <figcaption className="thumbnail-caption">
           {folio.name}
         </figcaption>
 

--- a/editioncrafter/src/component/ImageView.js
+++ b/editioncrafter/src/component/ImageView.js
@@ -24,8 +24,6 @@ const ImageView = (props) => {
   // const [onZoomOut, setOnZoomOut] = useState(() => null);
   // const [onZoomIn, setOnZoomIn] = useState(() => null);
 
-
-
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -48,7 +46,7 @@ const ImageView = (props) => {
     viewer.viewport.zoomTo(viewer.viewport.getMaxZoom());
   };
 
-  const onZoomFixed_2= (e) => {
+  const onZoomFixed_2 = (e) => {
     viewer.viewport.zoomTo((viewer.viewport.getMaxZoom() / 2));
   };
 
@@ -58,11 +56,11 @@ const ImageView = (props) => {
 
   const onZoomIn = (e) => {
     console.log(viewer.viewport.fitVertically());
-    viewer.viewport.zoomBy(2)
+    viewer.viewport.zoomBy(2);
   };
 
   const onZoomOut = (e) => {
-    viewer.viewport.zoomBy(0.5)
+    viewer.viewport.zoomBy(0.5);
   };
 
   useEffect(() => {
@@ -100,7 +98,7 @@ const ImageView = (props) => {
         showNavigationControl: false,
         zoomPerClick: 2,
         gestureSettingsMouse: {
-          clickToZoom: false
+          clickToZoom: false,
         },
       });
 
@@ -147,36 +145,36 @@ const ImageView = (props) => {
   return (
     <div>
       { tileSource
-      ? (
-      <div className={`image-view imageViewComponent ${props.side}`} style={{ position: "relative" }}>
-        <Navigation
-          side={props.side}
-          documentView={props.documentView}
-          documentViewActions={props.documentViewActions}
-          documentName={props.document.variorum && props.document.folioIndex[props.folioID].doc_id}
-        />
-        <ImageZoomControl
-          side={props.side}
-          documentView={props.documentView}
-          onZoomFixed_1={onZoomFixed_1}
-          onZoomFixed_2={onZoomFixed_2}
-          onZoomFixed_3={onZoomFixed_3}
-          onZoomGrid={onZoomGrid}
-          onZoomIn={onZoomIn}
-          onZoomOut={onZoomOut}
-          viewer={viewer}
-        />
-        <SeaDragonComponent
-          key={props.folioID}
-          side={props.side}
-          tileSource={tileSource}
-          initViewer={initViewer}
-          loading={loading}
-        />
-      </div>
-      ) : (
-        <BigRingSpinner color="dark" delay={300} />
-      )}
+        ? (
+          <div className={`image-view imageViewComponent ${props.side}`} style={{ position: 'relative' }}>
+            <Navigation
+              side={props.side}
+              documentView={props.documentView}
+              documentViewActions={props.documentViewActions}
+              documentName={props.document.variorum && props.document.folioIndex[props.folioID].doc_id}
+            />
+            <ImageZoomControl
+              side={props.side}
+              documentView={props.documentView}
+              onZoomFixed_1={onZoomFixed_1}
+              onZoomFixed_2={onZoomFixed_2}
+              onZoomFixed_3={onZoomFixed_3}
+              onZoomGrid={onZoomGrid}
+              onZoomIn={onZoomIn}
+              onZoomOut={onZoomOut}
+              viewer={viewer}
+            />
+            <SeaDragonComponent
+              key={props.folioID}
+              side={props.side}
+              tileSource={tileSource}
+              initViewer={initViewer}
+              loading={loading}
+            />
+          </div>
+        ) : (
+          <BigRingSpinner color="dark" delay={300} />
+        )}
     </div>
   );
 };

--- a/editioncrafter/src/component/Navigation.js
+++ b/editioncrafter/src/component/Navigation.js
@@ -13,7 +13,7 @@ import AlphabetLinks from './AlphabetLinks';
 import useIsWidthUp from '../hooks/useIsWidthUp';
 
 const initialPopoverObj = {
-  anchorEl: null
+  anchorEl: null,
 };
 
 const Navigation = (props) => {
@@ -38,7 +38,7 @@ const Navigation = (props) => {
 
   const onGoToGrid = (event) => {
     props.documentViewActions.changeTranscriptionType(props.side, 'g');
-  }
+  };
 
   const toggleHelp = (event) => {
     setOpenHelp(!openHelp);
@@ -123,7 +123,7 @@ const Navigation = (props) => {
 
   const revealJumpBox = (event) => {
     setPopover({
-      anchorEl: event.currentTarget
+      anchorEl: event.currentTarget,
     });
   };
 
@@ -158,7 +158,7 @@ const Navigation = (props) => {
   const selectColorStyle = documentView[side].transcriptionType === 'f' ? { color: 'white' } : { color: 'black' };
   const selectClass = documentView[side].transcriptionType === 'f' ? 'dark' : 'light';
   const showButtonsStyle = documentView[side].transcriptionType === 'glossary' ? { visibility: 'hidden' } : { visibility: 'visible' };
-  const selectContainerStyle = { display: 'flex' }; //what's the reason we want this to be hidden sometimes?
+  const selectContainerStyle = { display: 'flex' }; // what's the reason we want this to be hidden sometimes?
   let lockIconClass = (documentView.linkedMode) ? 'fa fa-lock' : 'fa fa-lock-open';
   if (!documentView.bookMode) {
     lockIconClass += ' active';
@@ -179,12 +179,12 @@ const Navigation = (props) => {
           { documentView[side].transcriptionType !== 'glossary' ? (
 
             <div id="tool-bar-buttons" className="breadcrumbs" style={showButtonsStyle}>
-              <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px' }}> 
-                <span 
-                  className="fas fa-th" 
-                  style={{ cursor: documentView[side].transcriptionType !== 'g' ? 'pointer' : 'default', padding: '0 15px' }} 
-                  title={documentView[side].transcriptionType !== 'g' && "Return to Grid View"} 
-                  onClick={documentView[side].transcriptionType !== 'g' && onGoToGrid} 
+              <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px' }}>
+                <span
+                  className="fas fa-th"
+                  style={{ cursor: documentView[side].transcriptionType !== 'g' ? 'pointer' : 'default', padding: '0 15px' }}
+                  title={documentView[side].transcriptionType !== 'g' && 'Return to Grid View'}
+                  onClick={documentView[side].transcriptionType !== 'g' && onGoToGrid}
                 />
 
                 <span
@@ -192,24 +192,23 @@ const Navigation = (props) => {
                   onClick={toggleLockmode}
                   className={lockIconClass}
                 />
-                                          
+
                 <span
                   title="Toggle book mode"
                   onClick={toggleBookmode}
                   className={bookIconClass}
                 />
-                                      
+
                 <span
                   title="Toggle XML mode"
                   onClick={toggleXMLMode}
                   style={{ paddingRight: '15px' }}
                   className={imageViewActive ? 'invisible' : xmlIconClass}
                 />
-                                              
+
                 {/* <span title="Toggle single column mode"  onClick={this.toggleColumns}
                                                         className={columnIconClass}></span> */}
-                                              
-                
+
                 <span
                   title="Go back"
                   onClick={changeCurrentFolio}
@@ -219,7 +218,6 @@ const Navigation = (props) => {
 
                   <FaArrowCircleLeft />
 
-                
                 </span>
 
                 <span
@@ -250,7 +248,7 @@ const Navigation = (props) => {
 
               <JumpToFolio
                 side={side}
-                anchorEl={popover.anchorEl}                                        
+                anchorEl={popover.anchorEl}
                 submitHandler={documentViewActions.jumpToFolio}
                 blurHandler={onJumpBoxBlur}
               />
@@ -273,9 +271,11 @@ const Navigation = (props) => {
               <MenuItem value="f" key="f">
                 {DocumentHelper.transcriptionTypeLabels.f}
               </MenuItem>
-              { props.glossary && <MenuItem value="glossary" key="glossary">
+              { props.glossary && (
+              <MenuItem value="glossary" key="glossary">
                 {DocumentHelper.transcriptionTypeLabels.glossary}
-              </MenuItem> }
+              </MenuItem>
+              ) }
             </Select>
             <span
               title="Toggle folio help"
@@ -300,12 +300,12 @@ const Navigation = (props) => {
           { documentView[side].transcriptionType !== 'glossary' ? (
 
             <div id="tool-bar-buttons" className="breadcrumbsNarrow" style={showButtonsStyle}>
-                
-              <span 
-                className="fas fa-th" 
-                style={{ cursor: documentView[side].transcriptionType !== 'g' ? 'pointer' : 'default', padding: '0 15px' }} 
-                title={documentView[side].transcriptionType !== 'g' && "Return to Grid View"} 
-                onClick={documentView[side].transcriptionType !== 'g' && onGoToGrid} 
+
+              <span
+                className="fas fa-th"
+                style={{ cursor: documentView[side].transcriptionType !== 'g' ? 'pointer' : 'default', padding: '0 15px' }}
+                title={documentView[side].transcriptionType !== 'g' && 'Return to Grid View'}
+                onClick={documentView[side].transcriptionType !== 'g' && onGoToGrid}
               />
                                                 &nbsp;
               <span
@@ -317,26 +317,26 @@ const Navigation = (props) => {
               { imageViewActive && (
                 <>
                   <span
-                  title="Go back"
-                  onClick={changeCurrentFolio}
-                  data-id={documentView[side].previousFolioShortID}
-                  className={(documentView[side].hasPrevious) ? 'arrow' : 'arrow disabled'}
-                >
-                  {' '}
-                  <FaArrowCircleLeft />
-                  {' '}
-  
-                </span>
-  
-                <span
-                  title="Go forward"
-                  onClick={changeCurrentFolio}
-                  data-id={documentView[side].nextFolioShortID}
-                  className={(documentView[side].hasNext) ? 'arrow' : 'arrow disabled'}
-                >
-                  {' '}
-                  <FaArrowCircleRight />
-                </span>
+                    title="Go back"
+                    onClick={changeCurrentFolio}
+                    data-id={documentView[side].previousFolioShortID}
+                    className={(documentView[side].hasPrevious) ? 'arrow' : 'arrow disabled'}
+                  >
+                    {' '}
+                    <FaArrowCircleLeft />
+                    {' '}
+
+                  </span>
+
+                  <span
+                    title="Go forward"
+                    onClick={changeCurrentFolio}
+                    data-id={documentView[side].nextFolioShortID}
+                    className={(documentView[side].hasNext) ? 'arrow' : 'arrow disabled'}
+                  >
+                    {' '}
+                    <FaArrowCircleRight />
+                  </span>
                 </>
               )}
 
@@ -358,9 +358,11 @@ const Navigation = (props) => {
               <MenuItem value="f" key="f">
                 {DocumentHelper.transcriptionTypeLabels.f}
               </MenuItem>
-              { props.glossary && <MenuItem value="glossary" key="glossary">
+              { props.glossary && (
+              <MenuItem value="glossary" key="glossary">
                 {DocumentHelper.transcriptionTypeLabels.glossary}
-              </MenuItem> }
+              </MenuItem>
+              ) }
             </Select>
             <span
               title="Toggle folio help"
@@ -386,7 +388,7 @@ const Navigation = (props) => {
 function mapStateToProps(state) {
   return {
     document: state.document,
-    glossary: !!state.glossary.URL
+    glossary: !!state.glossary.URL,
   };
 }
 

--- a/editioncrafter/src/component/RingSpinner.js
+++ b/editioncrafter/src/component/RingSpinner.js
@@ -1,23 +1,37 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react';
 
 // create an inline spinner (uses Pure CSS Loaders: https://loading.io/css/)
 export function InlineRingSpinner(foregroundColor) {
-    // color can be 'light' or 'dark'
-    return <div className="inline-ring-spinner"><div className={foregroundColor}></div><div></div><div></div><div></div></div>
+  // color can be 'light' or 'dark'
+  return (
+    <div className="inline-ring-spinner">
+      <div className={foregroundColor} />
+      <div />
+      <div />
+      <div />
+    </div>
+  );
 }
 
 export function BigRingSpinner(props) {
-    const { delay = 0, color = 'dark' } = props;
-    const [show, setShow] = useState(delay === 0);
+  const { delay = 0, color = 'dark' } = props;
+  const [show, setShow] = useState(delay === 0);
 
-    useEffect(() => {
-        if (delay > 0) {
-            const timer = setTimeout(() => {
-                setShow(true)
-            }, delay);
-            return () => clearTimeout(timer);
-        }
-    }, []);
+  useEffect(() => {
+    if (delay > 0) {
+      const timer = setTimeout(() => {
+        setShow(true);
+      }, delay);
+      return () => clearTimeout(timer);
+    }
+  }, []);
 
-    return show ? <div className={`big-ring-spinner ${color}`}><div></div><div></div><div></div><div></div></div> : <div></div>
+  return show ? (
+    <div className={`big-ring-spinner ${color}`}>
+      <div />
+      <div />
+      <div />
+      <div />
+    </div>
+  ) : <div />;
 }

--- a/editioncrafter/src/component/SeaDragonComponent.js
+++ b/editioncrafter/src/component/SeaDragonComponent.js
@@ -1,4 +1,6 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useEffect, useMemo, useRef, useState,
+} from 'react';
 import { BigRingSpinner } from './RingSpinner';
 
 const SeaDragonComponent = (props) => {

--- a/editioncrafter/src/model/Folio.js
+++ b/editioncrafter/src/model/Folio.js
@@ -3,7 +3,7 @@ import { layoutMargin3 } from './folioLayout';
 
 export async function loadFolio(folioData) {
   if (folioData.loading) {
-    return folioData
+    return folioData;
   }
 
   folioData.loading = true;
@@ -11,33 +11,35 @@ export async function loadFolio(folioData) {
   const transcriptionTypes = Object.keys(folio.annotationURLs);
   const transcriptionTypeTracker = Object.fromEntries(transcriptionTypes.map((t) => [t, false]));
 
+  const isIIIF = folio.image_zoom_url.endsWith('.json');
+
   if (transcriptionTypes.length > 0) {
-    const response = await fetch(folio.image_zoom_url)
-    const imageServerResponse = await response.json()
+    const response = await fetch(folio.image_zoom_url);
+    const imageServerResponse = await response.json();
     // Handle the image server response
     folio.tileSource = new OpenSeadragon.IIIFTileSource(imageServerResponse);
 
-    for (const transcriptionType of transcriptionTypes) {
+    for await (const transcriptionType of transcriptionTypes) {
       const { htmlURL, xmlURL } = folio.annotationURLs[transcriptionType];
       if (!folio.transcription) folio.transcription = {};
       folio.transcription[transcriptionType] = {};
 
       try {
-        const htmlURLResponse = await fetch(htmlURL)
-        const xmlURLResponse = await fetch(xmlURL)
-        const html = await htmlURLResponse.text()
-        const xml = await xmlURLResponse.text()
+        const htmlURLResponse = await fetch(htmlURL);
+        const xmlURLResponse = await fetch(xmlURL);
+        const html = await htmlURLResponse.text();
+        const xml = await xmlURLResponse.text();
         const transcription = parseTranscription(html, xml);
         if (!transcription) {
-          throw new Error(`Unable to load transcription: ${htmlURL}`)
+          throw new Error(`Unable to load transcription: ${htmlURL}`);
         } else {
           folio.transcription[transcriptionType] = transcription;
           folio.loading = false;
           transcriptionTypeTracker[transcriptionType] = true;
-        }  
-      } catch(error) {
-          folioData.loading = false;
-          throw error;
+        }
+      } catch (error) {
+        folioData.loading = false;
+        throw error;
       }
     }
 
@@ -45,19 +47,25 @@ export async function loadFolio(folioData) {
     if (Object.values(transcriptionTypeTracker).filter(v => !v).length === 0) {
       return folio;
     }
-  } else {
+  } else if (isIIIF) {
     // if there is no annotatation list, just load the image and provide a blank transcription
     try {
-      const response = await fetch(folio.image_zoom_url)
-      const imageServerResponse = await response.json()
+      const response = await fetch(folio.image_zoom_url);
+      const imageServerResponse = await response.json();
       folio.tileSource = new OpenSeadragon.IIIFTileSource(imageServerResponse);
       folio.loading = false;
-      return folio
-    } 
-    catch(error) {
-        folioData.loading = false;
-        throw error;
+      return folio;
+    } catch (error) {
+      folioData.loading = false;
+      throw error;
     }
+  } else {
+    folio.tileSource = new OpenSeadragon.ImageTileSource({
+      type: 'image',
+      url: folio.image_zoom_url,
+    });
+    folio.loading = false;
+    return folio;
   }
 }
 

--- a/editioncrafter/src/saga/RouteListenerSaga.js
+++ b/editioncrafter/src/saga/RouteListenerSaga.js
@@ -44,7 +44,7 @@ function* resolveDocumentManifest() {
       return variorumManifest;
     }
     const singleResponse = yield fetch(document.manifestURL);
-    const json = yield singleResponse.json()
+    const json = yield singleResponse.json();
     yield putResolveAction('DocumentActions.loadDocument', json);
     return json;
   }
@@ -87,7 +87,7 @@ function* resolveGlossary() {
   // NOTE: need to figure out how to deal with glossary for multidocument manifests
   if (!glossary.loaded && glossary.URL) {
     const response = yield fetch(glossary.URL);
-    const json = yield response.json()
+    const json = yield response.json();
     yield putResolveAction('GlossaryActions.loadGlossary', json);
   }
 }

--- a/editioncrafter/src/scss/_imageView.scss
+++ b/editioncrafter/src/scss/_imageView.scss
@@ -23,7 +23,7 @@
 	.imageViewComponent .navigationComponent {
 		position: absolute;
 	}
-	
+
 	.a9s-annotation.a9s-annotation.selected > rect,
 	.a9s-annotation.a9s-annotation.selected > polygon
 	 {

--- a/editioncrafter/src/scss/_navigation.scss
+++ b/editioncrafter/src/scss/_navigation.scss
@@ -105,7 +105,7 @@
       
       }
       
-      .imageViewComponent .navigationComponentNarrow {
+       .imageViewComponent .navigationComponentNarrow{
             background-color: rgba(0,0,0,1);
             color: #ffffff;
             border-radius: 0;

--- a/editioncrafter/src/scss/editioncrafter.scss
+++ b/editioncrafter/src/scss/editioncrafter.scss
@@ -9,7 +9,7 @@
 @import url('https://fonts.googleapis.com/icon?family=Material+Icons');
 /*
 	FontAwesome icon font http://fontawesome.io/
-	FIXME: This is still used by the imageView control panel, the rest of the app uses FA5 react npm module
+	FIXME: This is still used by the ImageView control panel, the rest of the app uses FA5 react npm module
 */
 @import url("https://use.fontawesome.com/releases/v5.0.8/css/all.css");
 

--- a/editioncrafter/static/cats-example/html/index.html
+++ b/editioncrafter/static/cats-example/html/index.html
@@ -1,0 +1,71 @@
+<tei-tei data-xmlns="http://www.tei-c.org/ns/1.0" data-origname="TEI">
+      <tei-teiheader data-origname="teiHeader">
+          <tei-filedesc data-origname="fileDesc">
+              <tei-titlestmt data-origname="titleStmt">
+                  <tei-title data-origname="title">
+                      <!-- Your Title Here -->
+                  </tei-title>
+              </tei-titlestmt>
+              <tei-publicationstmt data-origname="publicationStmt">
+                  <tei-p data-origname="p" data-empty=""></tei-p>
+              </tei-publicationstmt>
+              <tei-sourcedesc data-origname="sourceDesc">
+                  <tei-p data-origname="p" data-empty=""></tei-p>
+              </tei-sourcedesc>
+          </tei-filedesc>
+      </tei-teiheader>
+
+      <tei-facsimile data-origname="facsimile">
+                    <tei-surface xml:id="f000" id="f000" ulx="0" uly="0" lrx="2560" lry="1920" data-origname="surface">
+            <tei-label data-origname="label">Page 0</tei-label>
+            <tei-graphic mimetype="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/thumb/1/16/Kot_Leon.JPG/2560px-Kot_Leon.JPG" data-origname="graphic" data-empty=""></tei-graphic>
+          </tei-surface>
+          <tei-surface xml:id="f001" id="f001" ulx="0" uly="0" lrx="554" lry="567" data-origname="surface">
+            <tei-label data-origname="label">Page 1</tei-label>
+            <tei-graphic mimetype="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/c/ca/Black_white_cat_on_fence.jpg" data-origname="graphic" data-empty=""></tei-graphic>
+          </tei-surface>
+          <tei-surface xml:id="f002" id="f002" ulx="0" uly="0" lrx="1627" lry="1220" data-origname="surface">
+            <tei-label data-origname="label">Page 2</tei-label>
+            <tei-graphic mimetype="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/8/82/Cat_Eyes.jpg" data-origname="graphic" data-empty=""></tei-graphic>
+          </tei-surface>
+          <tei-surface xml:id="f003" id="f003" ulx="0" uly="0" lrx="768" lry="768" data-origname="surface">
+            <tei-label data-origname="label">Page 3</tei-label>
+            <tei-graphic mimetype="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/2/2f/Cat_domestic_%28undated_photo%3B_2013_upload%3B_cropped_2022%29.jpg" data-origname="graphic" data-empty=""></tei-graphic>
+          </tei-surface>
+          <tei-surface xml:id="f004" id="f004" ulx="0" uly="0" lrx="1280" lry="1707" data-origname="surface">
+            <tei-label data-origname="label">Page 4</tei-label>
+            <tei-graphic mimetype="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Gr%C3%BCne_Augen_einer_Katze.JPG/1280px-Gr%C3%BCne_Augen_einer_Katze.JPG" data-origname="graphic" data-empty=""></tei-graphic>
+          </tei-surface>
+          <tei-surface xml:id="f005" id="f005" ulx="0" uly="0" lrx="1612" lry="1727" data-origname="surface">
+            <tei-label data-origname="label">Page 5</tei-label>
+            <tei-graphic mimetype="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/e/ef/Female-cat-named-Liebe.jpg" data-origname="graphic" data-empty=""></tei-graphic>
+          </tei-surface>
+          <tei-surface xml:id="f006" id="f006" ulx="0" uly="0" lrx="1024" lry="1820" data-origname="surface">
+            <tei-label data-origname="label">Page 6</tei-label>
+            <tei-graphic mimetype="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Abessijn_kijkt_uit_het_raam..jpg/1024px-Abessijn_kijkt_uit_het_raam..jpg" data-origname="graphic" data-empty=""></tei-graphic>
+          </tei-surface>
+          <tei-surface xml:id="f007" id="f007" ulx="0" uly="0" lrx="2560" lry="1707" data-origname="surface">
+            <tei-label data-origname="label">Page 7</tei-label>
+            <tei-graphic mimetype="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/thumb/1/11/Animals_%2816969925571%29.jpg/2560px-Animals_%2816969925571%29.jpg" data-origname="graphic" data-empty=""></tei-graphic>
+          </tei-surface>
+          <tei-surface xml:id="f008" id="f008" ulx="0" uly="0" lrx="2560" lry="1829" data-origname="surface">
+            <tei-label data-origname="label">Page 8</tei-label>
+            <tei-graphic mimetype="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Attentive_grey_stray_cat.jpg/2560px-Attentive_grey_stray_cat.jpg" data-origname="graphic" data-empty=""></tei-graphic>
+          </tei-surface>
+          <tei-surface xml:id="f009" id="f009" ulx="0" uly="0" lrx="1280" lry="1707" data-origname="surface">
+            <tei-label data-origname="label">Page 9</tei-label>
+            <tei-graphic mimetype="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/Barbeque_cat_%289382542117%29.jpg/1280px-Barbeque_cat_%289382542117%29.jpg" data-origname="graphic" data-empty=""></tei-graphic>
+          </tei-surface>
+          <tei-surface xml:id="f010" id="f010" ulx="0" uly="0" lrx="1920" lry="1556" data-origname="surface">
+            <tei-label data-origname="label">Page 10</tei-label>
+            <tei-graphic mimetype="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/thumb/8/85/Black_Cat_%288030060974%29.jpg/1920px-Black_Cat_%288030060974%29.jpg" data-origname="graphic" data-empty=""></tei-graphic>
+          </tei-surface>
+
+      </tei-facsimile>
+
+      <tei-text xml:id="transcription" id="transcription" data-origname="text">
+          <tei-body data-origname="body">
+              <tei-p data-origname="p">Modify xml:id as desired and replace this with your text.</tei-p>
+          </tei-body>
+      </tei-text>
+  </tei-tei>

--- a/editioncrafter/static/cats-example/html/transcription/index.html
+++ b/editioncrafter/static/cats-example/html/transcription/index.html
@@ -1,0 +1,5 @@
+<tei-text xml:id="transcription" id="transcription" data-origname="text">
+          <tei-body data-origname="body">
+              <tei-p data-origname="p">Modify xml:id as desired and replace this with your text.</tei-p>
+          </tei-body>
+      </tei-text>

--- a/editioncrafter/static/cats-example/iiif/manifest.json
+++ b/editioncrafter/static/cats-example/iiif/manifest.json
@@ -1,0 +1,397 @@
+{
+	"@context": [
+		"http://www.w3.org/ns/anno.jsonld",
+		"http://iiif.io/api/presentation/3/context.json"
+	],
+	"id": "http://localhost:8080/out/iiif/manifest.json",
+	"type": "Manifest",
+	"items": [
+		{
+			"id": "http://localhost:8080/out/iiif/canvas/f000",
+			"type": "Canvas",
+			"items": [
+				{
+					"id": "http://localhost:8080/out/iiif/canvas/f000/annotationpage/0",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"@context": "https://www.w3.org/ns/anno.jsonld",
+							"id": "http://localhost:8080/out/iiif/canvas/f000/annotationpage/0/annotation/0",
+							"type": "Annotation",
+							"motivation": "painting",
+							"body": {
+								"id": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/16/Kot_Leon.JPG/2560px-Kot_Leon.JPG",
+								"format": "image/jpeg",
+								"type": "Image",
+								"height": 1920,
+								"width": 2560
+							},
+							"target": "http://localhost:8080/out/iiif/canvas/f000"
+						}
+					]
+				}
+			],
+			"height": 1920,
+			"width": 2560,
+			"label": {
+				"none": [
+					"Page 0"
+				]
+			},
+			"annotations": []
+		},
+		{
+			"id": "http://localhost:8080/out/iiif/canvas/f001",
+			"type": "Canvas",
+			"items": [
+				{
+					"id": "http://localhost:8080/out/iiif/canvas/f001/annotationpage/0",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"@context": "https://www.w3.org/ns/anno.jsonld",
+							"id": "http://localhost:8080/out/iiif/canvas/f001/annotationpage/0/annotation/0",
+							"type": "Annotation",
+							"motivation": "painting",
+							"body": {
+								"id": "https://upload.wikimedia.org/wikipedia/commons/c/ca/Black_white_cat_on_fence.jpg",
+								"format": "image/jpeg",
+								"type": "Image",
+								"height": 567,
+								"width": 554
+							},
+							"target": "http://localhost:8080/out/iiif/canvas/f001"
+						}
+					]
+				}
+			],
+			"height": 567,
+			"width": 554,
+			"label": {
+				"none": [
+					"Page 1"
+				]
+			},
+			"annotations": []
+		},
+		{
+			"id": "http://localhost:8080/out/iiif/canvas/f002",
+			"type": "Canvas",
+			"items": [
+				{
+					"id": "http://localhost:8080/out/iiif/canvas/f002/annotationpage/0",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"@context": "https://www.w3.org/ns/anno.jsonld",
+							"id": "http://localhost:8080/out/iiif/canvas/f002/annotationpage/0/annotation/0",
+							"type": "Annotation",
+							"motivation": "painting",
+							"body": {
+								"id": "https://upload.wikimedia.org/wikipedia/commons/8/82/Cat_Eyes.jpg",
+								"format": "image/jpeg",
+								"type": "Image",
+								"height": 1220,
+								"width": 1627
+							},
+							"target": "http://localhost:8080/out/iiif/canvas/f002"
+						}
+					]
+				}
+			],
+			"height": 1220,
+			"width": 1627,
+			"label": {
+				"none": [
+					"Page 2"
+				]
+			},
+			"annotations": []
+		},
+		{
+			"id": "http://localhost:8080/out/iiif/canvas/f003",
+			"type": "Canvas",
+			"items": [
+				{
+					"id": "http://localhost:8080/out/iiif/canvas/f003/annotationpage/0",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"@context": "https://www.w3.org/ns/anno.jsonld",
+							"id": "http://localhost:8080/out/iiif/canvas/f003/annotationpage/0/annotation/0",
+							"type": "Annotation",
+							"motivation": "painting",
+							"body": {
+								"id": "https://upload.wikimedia.org/wikipedia/commons/2/2f/Cat_domestic_%28undated_photo%3B_2013_upload%3B_cropped_2022%29.jpg",
+								"format": "image/jpeg",
+								"type": "Image",
+								"height": 768,
+								"width": 768
+							},
+							"target": "http://localhost:8080/out/iiif/canvas/f003"
+						}
+					]
+				}
+			],
+			"height": 768,
+			"width": 768,
+			"label": {
+				"none": [
+					"Page 3"
+				]
+			},
+			"annotations": []
+		},
+		{
+			"id": "http://localhost:8080/out/iiif/canvas/f004",
+			"type": "Canvas",
+			"items": [
+				{
+					"id": "http://localhost:8080/out/iiif/canvas/f004/annotationpage/0",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"@context": "https://www.w3.org/ns/anno.jsonld",
+							"id": "http://localhost:8080/out/iiif/canvas/f004/annotationpage/0/annotation/0",
+							"type": "Annotation",
+							"motivation": "painting",
+							"body": {
+								"id": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Gr%C3%BCne_Augen_einer_Katze.JPG/1280px-Gr%C3%BCne_Augen_einer_Katze.JPG",
+								"format": "image/jpeg",
+								"type": "Image",
+								"height": 1707,
+								"width": 1280
+							},
+							"target": "http://localhost:8080/out/iiif/canvas/f004"
+						}
+					]
+				}
+			],
+			"height": 1707,
+			"width": 1280,
+			"label": {
+				"none": [
+					"Page 4"
+				]
+			},
+			"annotations": []
+		},
+		{
+			"id": "http://localhost:8080/out/iiif/canvas/f005",
+			"type": "Canvas",
+			"items": [
+				{
+					"id": "http://localhost:8080/out/iiif/canvas/f005/annotationpage/0",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"@context": "https://www.w3.org/ns/anno.jsonld",
+							"id": "http://localhost:8080/out/iiif/canvas/f005/annotationpage/0/annotation/0",
+							"type": "Annotation",
+							"motivation": "painting",
+							"body": {
+								"id": "https://upload.wikimedia.org/wikipedia/commons/e/ef/Female-cat-named-Liebe.jpg",
+								"format": "image/jpeg",
+								"type": "Image",
+								"height": 1727,
+								"width": 1612
+							},
+							"target": "http://localhost:8080/out/iiif/canvas/f005"
+						}
+					]
+				}
+			],
+			"height": 1727,
+			"width": 1612,
+			"label": {
+				"none": [
+					"Page 5"
+				]
+			},
+			"annotations": []
+		},
+		{
+			"id": "http://localhost:8080/out/iiif/canvas/f006",
+			"type": "Canvas",
+			"items": [
+				{
+					"id": "http://localhost:8080/out/iiif/canvas/f006/annotationpage/0",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"@context": "https://www.w3.org/ns/anno.jsonld",
+							"id": "http://localhost:8080/out/iiif/canvas/f006/annotationpage/0/annotation/0",
+							"type": "Annotation",
+							"motivation": "painting",
+							"body": {
+								"id": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Abessijn_kijkt_uit_het_raam..jpg/1024px-Abessijn_kijkt_uit_het_raam..jpg",
+								"format": "image/jpeg",
+								"type": "Image",
+								"height": 1820,
+								"width": 1024
+							},
+							"target": "http://localhost:8080/out/iiif/canvas/f006"
+						}
+					]
+				}
+			],
+			"height": 1820,
+			"width": 1024,
+			"label": {
+				"none": [
+					"Page 6"
+				]
+			},
+			"annotations": []
+		},
+		{
+			"id": "http://localhost:8080/out/iiif/canvas/f007",
+			"type": "Canvas",
+			"items": [
+				{
+					"id": "http://localhost:8080/out/iiif/canvas/f007/annotationpage/0",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"@context": "https://www.w3.org/ns/anno.jsonld",
+							"id": "http://localhost:8080/out/iiif/canvas/f007/annotationpage/0/annotation/0",
+							"type": "Annotation",
+							"motivation": "painting",
+							"body": {
+								"id": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/11/Animals_%2816969925571%29.jpg/2560px-Animals_%2816969925571%29.jpg",
+								"format": "image/jpeg",
+								"type": "Image",
+								"height": 1707,
+								"width": 2560
+							},
+							"target": "http://localhost:8080/out/iiif/canvas/f007"
+						}
+					]
+				}
+			],
+			"height": 1707,
+			"width": 2560,
+			"label": {
+				"none": [
+					"Page 7"
+				]
+			},
+			"annotations": []
+		},
+		{
+			"id": "http://localhost:8080/out/iiif/canvas/f008",
+			"type": "Canvas",
+			"items": [
+				{
+					"id": "http://localhost:8080/out/iiif/canvas/f008/annotationpage/0",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"@context": "https://www.w3.org/ns/anno.jsonld",
+							"id": "http://localhost:8080/out/iiif/canvas/f008/annotationpage/0/annotation/0",
+							"type": "Annotation",
+							"motivation": "painting",
+							"body": {
+								"id": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Attentive_grey_stray_cat.jpg/2560px-Attentive_grey_stray_cat.jpg",
+								"format": "image/jpeg",
+								"type": "Image",
+								"height": 1829,
+								"width": 2560
+							},
+							"target": "http://localhost:8080/out/iiif/canvas/f008"
+						}
+					]
+				}
+			],
+			"height": 1829,
+			"width": 2560,
+			"label": {
+				"none": [
+					"Page 8"
+				]
+			},
+			"annotations": []
+		},
+		{
+			"id": "http://localhost:8080/out/iiif/canvas/f009",
+			"type": "Canvas",
+			"items": [
+				{
+					"id": "http://localhost:8080/out/iiif/canvas/f009/annotationpage/0",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"@context": "https://www.w3.org/ns/anno.jsonld",
+							"id": "http://localhost:8080/out/iiif/canvas/f009/annotationpage/0/annotation/0",
+							"type": "Annotation",
+							"motivation": "painting",
+							"body": {
+								"id": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/Barbeque_cat_%289382542117%29.jpg/1280px-Barbeque_cat_%289382542117%29.jpg",
+								"format": "image/jpeg",
+								"type": "Image",
+								"height": 1707,
+								"width": 1280
+							},
+							"target": "http://localhost:8080/out/iiif/canvas/f009"
+						}
+					]
+				}
+			],
+			"height": 1707,
+			"width": 1280,
+			"label": {
+				"none": [
+					"Page 9"
+				]
+			},
+			"annotations": []
+		},
+		{
+			"id": "http://localhost:8080/out/iiif/canvas/f010",
+			"type": "Canvas",
+			"items": [
+				{
+					"id": "http://localhost:8080/out/iiif/canvas/f010/annotationpage/0",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"@context": "https://www.w3.org/ns/anno.jsonld",
+							"id": "http://localhost:8080/out/iiif/canvas/f010/annotationpage/0/annotation/0",
+							"type": "Annotation",
+							"motivation": "painting",
+							"body": {
+								"id": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/85/Black_Cat_%288030060974%29.jpg/1920px-Black_Cat_%288030060974%29.jpg",
+								"format": "image/jpeg",
+								"type": "Image",
+								"height": 1556,
+								"width": 1920
+							},
+							"target": "http://localhost:8080/out/iiif/canvas/f010"
+						}
+					]
+				}
+			],
+			"height": 1556,
+			"width": 1920,
+			"label": {
+				"none": [
+					"Page 10"
+				]
+			},
+			"annotations": []
+		}
+	],
+	"label": {
+		"en": [
+			"out"
+		]
+	},
+	"seeAlso": [
+		{
+			"id": "https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/glossary.json",
+			"type": "Dataset",
+			"label": "Glossary",
+			"format": "text/json"
+		}
+	]
+}

--- a/editioncrafter/static/cats-example/tei/index.xml
+++ b/editioncrafter/static/cats-example/tei/index.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <TEI xmlns="http://www.tei-c.org/ns/1.0">
+      <teiHeader>
+          <fileDesc>
+              <titleStmt>
+                  <title>
+                      <!-- Your Title Here -->
+                  </title>
+              </titleStmt>
+              <publicationStmt>
+                  <p></p>
+              </publicationStmt>
+              <sourceDesc>
+                  <p></p>
+              </sourceDesc>
+          </fileDesc>
+      </teiHeader>
+
+      <facsimile >
+                    <surface xml:id="f000" ulx="0" uly="0" lrx="2560" lry="1920">
+            <label>Page 0</label>
+            <graphic mimeType="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/thumb/1/16/Kot_Leon.JPG/2560px-Kot_Leon.JPG" />
+          </surface>
+          <surface xml:id="f001" ulx="0" uly="0" lrx="554" lry="567">
+            <label>Page 1</label>
+            <graphic mimeType="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/c/ca/Black_white_cat_on_fence.jpg" />
+          </surface>
+          <surface xml:id="f002" ulx="0" uly="0" lrx="1627" lry="1220">
+            <label>Page 2</label>
+            <graphic mimeType="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/8/82/Cat_Eyes.jpg" />
+          </surface>
+          <surface xml:id="f003" ulx="0" uly="0" lrx="768" lry="768">
+            <label>Page 3</label>
+            <graphic mimeType="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/2/2f/Cat_domestic_%28undated_photo%3B_2013_upload%3B_cropped_2022%29.jpg" />
+          </surface>
+          <surface xml:id="f004" ulx="0" uly="0" lrx="1280" lry="1707">
+            <label>Page 4</label>
+            <graphic mimeType="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Gr%C3%BCne_Augen_einer_Katze.JPG/1280px-Gr%C3%BCne_Augen_einer_Katze.JPG" />
+          </surface>
+          <surface xml:id="f005" ulx="0" uly="0" lrx="1612" lry="1727">
+            <label>Page 5</label>
+            <graphic mimeType="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/e/ef/Female-cat-named-Liebe.jpg" />
+          </surface>
+          <surface xml:id="f006" ulx="0" uly="0" lrx="1024" lry="1820">
+            <label>Page 6</label>
+            <graphic mimeType="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Abessijn_kijkt_uit_het_raam..jpg/1024px-Abessijn_kijkt_uit_het_raam..jpg" />
+          </surface>
+          <surface xml:id="f007" ulx="0" uly="0" lrx="2560" lry="1707">
+            <label>Page 7</label>
+            <graphic mimeType="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/thumb/1/11/Animals_%2816969925571%29.jpg/2560px-Animals_%2816969925571%29.jpg" />
+          </surface>
+          <surface xml:id="f008" ulx="0" uly="0" lrx="2560" lry="1829">
+            <label>Page 8</label>
+            <graphic mimeType="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Attentive_grey_stray_cat.jpg/2560px-Attentive_grey_stray_cat.jpg" />
+          </surface>
+          <surface xml:id="f009" ulx="0" uly="0" lrx="1280" lry="1707">
+            <label>Page 9</label>
+            <graphic mimeType="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/Barbeque_cat_%289382542117%29.jpg/1280px-Barbeque_cat_%289382542117%29.jpg" />
+          </surface>
+          <surface xml:id="f010" ulx="0" uly="0" lrx="1920" lry="1556">
+            <label>Page 10</label>
+            <graphic mimeType="image/jpeg" url="https://upload.wikimedia.org/wikipedia/commons/thumb/8/85/Black_Cat_%288030060974%29.jpg/1920px-Black_Cat_%288030060974%29.jpg" />
+          </surface>
+
+      </facsimile>
+
+      <text xml:id="transcription">
+          <body>
+              <p>Modify xml:id as desired and replace this with your text.</p>
+          </body>
+      </text>
+  </TEI>

--- a/editioncrafter/static/cats-example/tei/transcription/index.xml
+++ b/editioncrafter/static/cats-example/tei/transcription/index.xml
@@ -1,0 +1,5 @@
+<text xmlns="http://www.tei-c.org/ns/1.0" xml:id="transcription">
+          <body>
+              <p>Modify xml:id as desired and replace this with your text.</p>
+          </body>
+      </text>

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -1,11 +1,11 @@
-import React, { useEffect, useState } from "react";
-import EditionCrafter from "../src/index";
+import React, { useEffect, useState } from 'react';
+import EditionCrafter from '../src/index';
 
 export const BowInTheCloud = () => (
   <EditionCrafter
     documentName="eng-415-145a"
     transcriptionTypes={{
-      "eng-415-145a": "Transcription",
+      'eng-415-145a': 'Transcription',
     }}
     iiifManifest="https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json"
   />
@@ -15,7 +15,7 @@ export const DyngleyFamily = () => (
   <EditionCrafter
     documentName="O.8.35"
     transcriptionTypes={{
-      transcription: "Translation",
+      transcription: 'Translation',
     }}
     iiifManifest="https://cu-mkp.github.io/dyngleyfamily-editioncrafter-data/O_8_35/iiif/manifest.json"
   />
@@ -25,10 +25,20 @@ export const NativeBoundUnbound = () => (
   <EditionCrafter
     documentName="FHL_007548733_TAOS_BAPTISMS_BATCH_2"
     transcriptionTypes={{
-      translation: "Translation",
-      transcription: "Transcription",
+      translation: 'Translation',
+      transcription: 'Transcription',
     }}
     iiifManifest="https://editioncrafter.org/taos-baptisms-example/iiif/manifest.json"
+  />
+);
+
+export const Cats = () => (
+  <EditionCrafter
+    documentName="cats"
+    transcriptionTypes={{
+      transcription: 'Transcription',
+    }}
+    iiifManifest="/cats-example/iiif/manifest.json"
   />
 );
 
@@ -36,10 +46,10 @@ export const BnFMsFr640 = () => (
   <EditionCrafter
     documentName="BnF Ms. Fr. 640"
     transcriptionTypes={{
-      tc: "Diplomatic (FR)",
-      tcn: "Normalized (FR)",
-      tl: "Translation (EN)",
-      test: "Test Field (EN)",
+      tc: 'Diplomatic (FR)',
+      tcn: 'Normalized (FR)',
+      tl: 'Translation (EN)',
+      test: 'Test Field (EN)',
     }}
     iiifManifest="https://editioncrafter.org-data/fr640_3r-3v-example/iiif/manifest.json"
     glossaryURL="https://editioncrafter.org-data/fr640_3r-3v-example/glossary.json"
@@ -51,7 +61,7 @@ export const IntervistePescatori = () => (
     threePanel
     documentName="Interviste Pescatori 1r-35v"
     transcriptionTypes={{
-      transcription: "Transcription",
+      transcription: 'Transcription',
     }}
     iiifManifest="https://cu-mkp.github.io/venice-editioncrafter-data/data/interviste-pescatori_1r-35v/iiif/manifest.json"
   />
@@ -62,49 +72,49 @@ export const OrnamentDesignTranslation = () => (
     documentName="Ornament : Design : Translation"
     documentInfo={{
       caryatidum: {
-        documentName: "caryatidum",
+        documentName: 'caryatidum',
         transcriptionTypes: {
-          "text-1": "Text 1",
-          "text-2": "Text 2",
+          'text-1': 'Text 1',
+          'text-2': 'Text 2',
         },
         iiifManifest:
-          "https://cu-mkp.github.io/odt-editioncrafter-data/texts/caryatidum/iiif/manifest.json",
+          'https://cu-mkp.github.io/odt-editioncrafter-data/texts/caryatidum/iiif/manifest.json',
       },
       grotisch_fur_alle_kunstler: {
-        documentName: "grotisch_fur_alle_kunstler",
+        documentName: 'grotisch_fur_alle_kunstler',
         transcriptionTypes: {
-          "text-1": "Text 1",
-          "text-2": "Text 2",
+          'text-1': 'Text 1',
+          'text-2': 'Text 2',
         },
         iiifManifest:
-          "https://cu-mkp.github.io/odt-editioncrafter-data/texts/grotisch_fur_alle_kunstler/iiif/manifest.json",
+          'https://cu-mkp.github.io/odt-editioncrafter-data/texts/grotisch_fur_alle_kunstler/iiif/manifest.json',
       },
       mansches_de_coutiaus: {
-        documentName: "mansches_de_coutiaus",
+        documentName: 'mansches_de_coutiaus',
         transcriptionTypes: {
-          "text-1": "Text 1",
-          "text-2": "Text 2",
+          'text-1': 'Text 1',
+          'text-2': 'Text 2',
         },
         iiifManifest:
-          "https://cu-mkp.github.io/odt-editioncrafter-data/texts/mansches_de_coutiaus/iiif/manifest.json",
+          'https://cu-mkp.github.io/odt-editioncrafter-data/texts/mansches_de_coutiaus/iiif/manifest.json',
       },
       passio_verbigenae: {
-        documentName: "passio_verbigenae",
+        documentName: 'passio_verbigenae',
         transcriptionTypes: {
-          "text-1": "Text 1",
-          "text-2": "Text 2",
+          'text-1': 'Text 1',
+          'text-2': 'Text 2',
         },
         iiifManifest:
-          "https://cu-mkp.github.io/odt-editioncrafter-data/texts/passio_verbigenae/iiif/manifest.json",
+          'https://cu-mkp.github.io/odt-editioncrafter-data/texts/passio_verbigenae/iiif/manifest.json',
       },
       veelderley_veranderinghe_van_grotissen: {
-        documentName: "veelderley_veranderinghe_van_grotissen",
+        documentName: 'veelderley_veranderinghe_van_grotissen',
         transcriptionTypes: {
-          "text-1": "Text 1",
-          "text-2": "Text 2",
+          'text-1': 'Text 1',
+          'text-2': 'Text 2',
         },
         iiifManifest:
-          "https://cu-mkp.github.io/odt-editioncrafter-data/texts/veelderley_veranderinghe_van_grotissen/iiif/manifest.json",
+          'https://cu-mkp.github.io/odt-editioncrafter-data/texts/veelderley_veranderinghe_van_grotissen/iiif/manifest.json',
       },
     }}
   />
@@ -113,17 +123,17 @@ export const OrnamentDesignTranslation = () => (
 export const embeddedDiv = () => (
   <div
     style={{
-      width: "1200px",
-      height: "600px",
-      margin: "0 auto",
-      fontSize: "9px",
+      width: '1200px',
+      height: '600px',
+      margin: '0 auto',
+      fontSize: '9px',
     }}
   >
     <EditionCrafter
       documentName="FHL_007548733_TAOS_BAPTISMS_BATCH_2"
       transcriptionTypes={{
-        translation: "Translation",
-        transcription: "Transcription",
+        translation: 'Translation',
+        transcription: 'Transcription',
       }}
       iiifManifest="https://editioncrafter.org/taos-baptisms-example/iiif/manifest.json"
     />
@@ -131,12 +141,12 @@ export const embeddedDiv = () => (
 );
 
 export const fullScreen = () => (
-  <div style={{ width: "100dvw", height: "100dvh" }}>
+  <div style={{ width: '100dvw', height: '100dvh' }}>
     <EditionCrafter
       documentName="FHL_007548733_TAOS_BAPTISMS_BATCH_2"
       transcriptionTypes={{
-        translation: "Translation",
-        transcription: "Transcription",
+        translation: 'Translation',
+        transcription: 'Transcription',
       }}
       iiifManifest="https://editioncrafter.org/taos-baptisms-example/iiif/manifest.json"
     />
@@ -145,18 +155,18 @@ export const fullScreen = () => (
 
 export const stateChange = () => {
   const [manifest, setManifest] = useState(
-    "https://editioncrafter.org/taos-baptisms-example/iiif/manifest.json"
+    'https://editioncrafter.org/taos-baptisms-example/iiif/manifest.json',
   );
   const [glossary, setGlossary] = useState(undefined);
-  const [title, setTitle] = useState("FHL_007548733_TAOS_BAPTISMS_BATCH_2");
+  const [title, setTitle] = useState('FHL_007548733_TAOS_BAPTISMS_BATCH_2');
 
   useEffect(() => {
     setTimeout(() => {
-      //setManifest('https://cu-mkp.github.io/dyngleyfamily-editioncrafter-data/O_8_35/iiif/manifest.json');
+      // setManifest('https://cu-mkp.github.io/dyngleyfamily-editioncrafter-data/O_8_35/iiif/manifest.json');
       setGlossary(
-        "https://editioncrafter.org-data/fr640_3r-3v-example/glossary.json"
+        'https://editioncrafter.org-data/fr640_3r-3v-example/glossary.json',
       );
-      setTitle("Taos Baptisms Batch 2");
+      setTitle('Taos Baptisms Batch 2');
     }, 10000);
   }, []);
 
@@ -164,8 +174,8 @@ export const stateChange = () => {
     <EditionCrafter
       documentName={title}
       transcriptionTypes={{
-        translation: "Translation",
-        transcription: "Transcription",
+        translation: 'Translation',
+        transcription: 'Transcription',
       }}
       iiifManifest={manifest}
       glossaryURL={glossary}
@@ -174,5 +184,5 @@ export const stateChange = () => {
 };
 
 export default {
-  title: "EditionCrafter",
+  title: 'EditionCrafter',
 };


### PR DESCRIPTION
# Summary

This PR adds support for displaying regular images, as opposed to just IIIF content.

- adds handling in a few different places to differentiate images from IIIF
- adds a new example project to the Storybook components called Cats, which is a collection of pictures of cats from Wikimedia

Also, this repo appeared to have ESLint set up and configured, but it hadn't been run recently so a lot of the code I worked with was covered in red squiggles. I added a `.vscode/settings.json` file to configure auto-formatting with ESLint on save. This should automatically run for anyone who uses VS Code to work in this repo, although it might require the ESLint extension to be installed. A lot of stuff in the diff is linting fixes from the format on save feature.