### PR TITLE
Fixing base Url in fr640 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ import EditionCrafter from '@cu-mkp/editioncrafter'
     tcn: 'Normalized (FR)',
     tl: 'Translation (EN)'
   }}
-  iiifManifest='https://editioncrafter.org-data/fr640_3r-3v-example/iiif/manifest.json'
-  glossaryURL='https://editioncrafter.org-data/fr640_3r-3v-example/glossary.json'
+  iiifManifest='https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json'
+  glossaryURL='https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/glossary.json'
 />
 ```
 
@@ -44,8 +44,8 @@ To include EditionCrafter in your HTML website, you need to create a `div` somew
      EditionCrafter.viewer({
          id: 'ec',
          documentName: 'BnF Ms. Fr. 640',
-         iiifManifest: 'https://editioncrafter.org-data/fr640_3r-3v-example/iiif/manifest.json',
-         glossaryURL: 'https://editioncrafter.org-data/fr640_3r-3v-example/glossary.json',
+         iiifManifest: 'https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json',
+         glossaryURL: 'https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/glossary.json',
          transcriptionTypes: {
            tc: 'Diplomatic (FR)',
            tcn: 'Normalized (FR)',

--- a/astro-web/public/taos-baptisms-example/iiif/manifest.json
+++ b/astro-web/public/taos-baptisms-example/iiif/manifest.json
@@ -3748,7 +3748,7 @@
   },
   "seeAlso": [
     {
-      "id": "https://editioncrafter.org-data/fr640_3r-3v-example/glossary.json",
+      "id": "https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/glossary.json",
       "type": "Dataset",
       "label": "Glossary",
       "format": "text/json"

--- a/astro-web/src/pages/getting-started/index.mdx
+++ b/astro-web/src/pages/getting-started/index.mdx
@@ -65,7 +65,7 @@ import EditionCrafter from '@cu-mkp/editioncrafter'
     tcn: 'Normalized (FR)',
     tl: 'Translation (EN)'
   }}
-  iiifManifest='https://editioncrafter.org-data/fr640_3r-3v-example/iiif/manifest.json'
+  iiifManifest='https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json'
 />
 ```
 
@@ -83,7 +83,7 @@ To include EditionCrafter in your HTML website, you need to create a `div` somew
      EditionCrafter.viewer({
          id: 'ec',
          documentName: 'BnF Ms. Fr. 640',
-         iiifManifest='https://editioncrafter.org-data/fr640_3r-3v-example/iiif/manifest.json',
+         iiifManifest='https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json',
          transcriptionTypes: {
            tc: 'Diplomatic (FR)',
            tcn: 'Normalized (FR)',

--- a/astro-web/src/pages/projects/bnf-ms-fr-640.astro
+++ b/astro-web/src/pages/projects/bnf-ms-fr-640.astro
@@ -16,8 +16,8 @@ const url = "https://edition640.makingandknowing.org/";
     tl: "Translation (EN)",
     test: "Test Field (EN)",
   }}
-  iiifManifest="https://editioncrafter.org-data/fr640_3r-3v-example/iiif/manifest.json"
-  glossaryURL="https://editioncrafter.org-data/fr640_3r-3v-example/glossary.json"
+  iiifManifest="https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json"
+  glossaryURL="https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/glossary.json"
   title="BnF Ms. Fr. 640"
   blurb={blurb}
   url={url}

--- a/editioncrafter-umd/README.md
+++ b/editioncrafter-umd/README.md
@@ -25,8 +25,8 @@ import EditionCrafter from '@cu-mkp/editioncrafter'
     tcn: 'Normalized (FR)',
     tl: 'Translation (EN)'
   }}
-  iiifManifest='https://editioncrafter.org-data/fr640_3r-3v-example/iiif/manifest.json'
-  glossaryURL='https://editioncrafter.org-data/fr640_3r-3v-example/glossary.json'
+  iiifManifest='https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json'
+  glossaryURL='https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/glossary.json'
 />
 ```
 
@@ -44,8 +44,8 @@ To include EditionCrafter in your HTML website, you need to create a `div` somew
      EditionCrafter.viewer({
          id: 'ec',
          documentName: 'BnF Ms. Fr. 640',
-         iiifManifest: 'https://editioncrafter.org-data/fr640_3r-3v-example/iiif/manifest.json',
-         glossaryURL: 'https://editioncrafter.org-data/fr640_3r-3v-example/glossary.json',
+         iiifManifest: 'https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json',
+         glossaryURL: 'https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/glossary.json',
          transcriptionTypes: {
            tc: 'Diplomatic (FR)',
            tcn: 'Normalized (FR)',

--- a/editioncrafter/README.md
+++ b/editioncrafter/README.md
@@ -25,7 +25,7 @@ import EditionCrafter from '@cu-mkp/editioncrafter'
     tcn: 'Normalized (FR)',
     tl: 'Translation (EN)'
   }}
-  iiifManifest='https://editioncrafter.org-data/fr640_3r-3v-example/iiif/manifest.json'
+  iiifManifest='https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json'
 />
 ```
 
@@ -43,7 +43,7 @@ To include EditionCrafter in your HTML website, you need to create a `div` somew
      EditionCrafter.viewer({
          id: 'ec',
          documentName: 'BnF Ms. Fr. 640',
-         iiifManifest='https://editioncrafter.org-data/fr640_3r-3v-example/iiif/manifest.json',
+         iiifManifest='https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json',
          transcriptionTypes: {
            tc: 'Diplomatic (FR)',
            tcn: 'Normalized (FR)',

--- a/editioncrafter/static/fr640_3r-3v-example/html/index.html
+++ b/editioncrafter/static/fr640_3r-3v-example/html/index.html
@@ -179,7 +179,7 @@
 			<tei-div data-origname="div">
 				<tei-p data-origname="p">instead of <tei-rs ref="#rs-m" data-origname="rs">fine turpentine</tei-rs>. And you can put into two <tei-rs ref="#rs-ms" data-origname="rs">lb</tei-rs> of <tei-del data-origname="del"><tei-rs ref="#rs-fr" data-origname="rs">tou</tei-rs></tei-del> <tei-rs ref="#rs-m" data-origname="rs">common turpentine</tei-rs> one <tei-rs ref="#rs-ms" data-origname="rs">lb</tei-rs> of <tei-rs ref="#rs-m" data-origname="rs">fine turpentine oil</tei-rs> &amp; do everything as with the other one. This one will cost you no more than five or six <tei-rs ref="#rs-cn" data-origname="rs">sous</tei-rs> per <tei-rs ref="#rs-ms" data-origname="rs">lb</tei-rs> &amp; is sold for 40 <tei-rs ref="#rs-cn" data-origname="rs">sous</tei-rs> per <tei-rs ref="#rs-ms" data-origname="rs">lb</tei-rs>.</tei-p>
 				<tei-figure data-origname="figure">
-					<tei-graphic url="https://editioncrafter.org-data/fr640_3r-3v-example/figures/p003v_1.png" data-origname="graphic">
+					<tei-graphic url="https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/figures/p003v_1.png" data-origname="graphic">
 						<tei-desc data-origname="desc" data-empty=""></tei-desc>
 					</tei-graphic>
 				</tei-figure>

--- a/editioncrafter/static/fr640_3r-3v-example/html/tl/f011.html
+++ b/editioncrafter/static/fr640_3r-3v-example/html/tl/f011.html
@@ -11,7 +11,7 @@
 					data-origname="rs">lb</tei-rs> &amp; is sold for 40 <tei-rs ref="#rs-cn"
 					data-origname="rs">sous</tei-rs> per <tei-rs ref="#rs-ms" data-origname="rs">lb</tei-rs>.</tei-p>
 			<tei-figure data-origname="figure">
-				<tei-graphic url="https://editioncrafter.org-data/fr640_3r-3v-example/figures/p003v_1.png"
+				<tei-graphic url="https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/figures/p003v_1.png"
 					data-origname="graphic">
 					<tei-desc data-origname="desc" data-empty=""></tei-desc>
 				</tei-graphic>

--- a/editioncrafter/static/fr640_3r-3v-example/html/tl/index.html
+++ b/editioncrafter/static/fr640_3r-3v-example/html/tl/index.html
@@ -116,7 +116,7 @@
 					data-origname="rs">lb</tei-rs> &amp; is sold for 40 <tei-rs ref="#rs-cn"
 					data-origname="rs">sous</tei-rs> per <tei-rs ref="#rs-ms" data-origname="rs">lb</tei-rs>.</tei-p>
 			<tei-figure data-origname="figure">
-				<tei-graphic url="https://editioncrafter.org-data/fr640_3r-3v-example/figures/p003v_1.png"
+				<tei-graphic url="https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/figures/p003v_1.png"
 					data-origname="graphic">
 					<tei-desc data-origname="desc" data-empty=""></tei-desc>
 				</tei-graphic>

--- a/editioncrafter/static/fr640_3r-3v-example/iiif/manifest.json
+++ b/editioncrafter/static/fr640_3r-3v-example/iiif/manifest.json
@@ -16810,7 +16810,7 @@
   },
   "seeAlso": [
     {
-      "id": "https://editioncrafter.org-data/fr640_3r-3v-example/glossary.json",
+      "id": "https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/glossary.json",
       "type": "Dataset",
       "label": "Glossary",
       "format": "text/json"

--- a/editioncrafter/static/fr640_3r-3v-example/tei/index.xml
+++ b/editioncrafter/static/fr640_3r-3v-example/tei/index.xml
@@ -179,7 +179,7 @@
 			<div>
 				<p>instead of <rs ref="#rs-m">fine turpentine</rs>. And you can put into two <rs ref="#rs-ms">lb</rs> of <del><rs ref="#rs-fr">tou</rs></del> <rs ref="#rs-m">common turpentine</rs> one <rs ref="#rs-ms">lb</rs> of <rs ref="#rs-m">fine turpentine oil</rs> &amp; do everything as with the other one. This one will cost you no more than five or six <rs ref="#rs-cn">sous</rs> per <rs ref="#rs-ms">lb</rs> &amp; is sold for 40 <rs ref="#rs-cn">sous</rs> per <rs ref="#rs-ms">lb</rs>.</p>
 				<figure>
-					<graphic url="https://editioncrafter.org-data/fr640_3r-3v-example/figures/p003v_1.png">
+					<graphic url="https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/figures/p003v_1.png">
 						<desc/>
 					</graphic>
 				</figure>

--- a/editioncrafter/static/fr640_3r-3v-example/tei/tl/f011.xml
+++ b/editioncrafter/static/fr640_3r-3v-example/tei/tl/f011.xml
@@ -2,7 +2,7 @@
 			<div>
 				<p>instead of <rs ref="#rs-m">fine turpentine</rs>. And you can put into two <rs ref="#rs-ms">lb</rs> of <del><rs ref="#rs-fr">tou</rs></del> <rs ref="#rs-m">common turpentine</rs> one <rs ref="#rs-ms">lb</rs> of <rs ref="#rs-m">fine turpentine oil</rs> &amp; do everything as with the other one. This one will cost you no more than five or six <rs ref="#rs-cn">sous</rs> per <rs ref="#rs-ms">lb</rs> &amp; is sold for 40 <rs ref="#rs-cn">sous</rs> per <rs ref="#rs-ms">lb</rs>.</p>
 				<figure>
-					<graphic url="https://editioncrafter.org-data/fr640_3r-3v-example/figures/p003v_1.png">
+					<graphic url="https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/figures/p003v_1.png">
 						<desc/>
 					</graphic>
 				</figure>

--- a/editioncrafter/static/fr640_3r-3v-example/tei/tl/index.xml
+++ b/editioncrafter/static/fr640_3r-3v-example/tei/tl/index.xml
@@ -28,7 +28,7 @@
 			<div>
 				<p>instead of <rs ref="#rs-m">fine turpentine</rs>. And you can put into two <rs ref="#rs-ms">lb</rs> of <del><rs ref="#rs-fr">tou</rs></del> <rs ref="#rs-m">common turpentine</rs> one <rs ref="#rs-ms">lb</rs> of <rs ref="#rs-m">fine turpentine oil</rs> &amp; do everything as with the other one. This one will cost you no more than five or six <rs ref="#rs-cn">sous</rs> per <rs ref="#rs-ms">lb</rs> &amp; is sold for 40 <rs ref="#rs-cn">sous</rs> per <rs ref="#rs-ms">lb</rs>.</p>
 				<figure>
-					<graphic url="https://editioncrafter.org-data/fr640_3r-3v-example/figures/p003v_1.png">
+					<graphic url="https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/figures/p003v_1.png">
 						<desc/>
 					</graphic>
 				</figure>

--- a/editioncrafter/static/taos-baptisms-example/iiif/manifest.json
+++ b/editioncrafter/static/taos-baptisms-example/iiif/manifest.json
@@ -3748,7 +3748,7 @@
   },
   "seeAlso": [
     {
-      "id": "https://editioncrafter.org-data/fr640_3r-3v-example/glossary.json",
+      "id": "https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/glossary.json",
       "type": "Dataset",
       "label": "Glossary",
       "format": "text/json"

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -41,8 +41,8 @@ export const BnFMsFr640 = () => (
       tl: "Translation (EN)",
       test: "Test Field (EN)",
     }}
-    iiifManifest="https://editioncrafter.org-data/fr640_3r-3v-example/iiif/manifest.json"
-    glossaryURL="https://editioncrafter.org-data/fr640_3r-3v-example/glossary.json"
+    iiifManifest="https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/iiif/manifest.json"
+    glossaryURL="https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/glossary.json"
   />
 );
 
@@ -154,7 +154,7 @@ export const stateChange = () => {
     setTimeout(() => {
       //setManifest('https://cu-mkp.github.io/dyngleyfamily-editioncrafter-data/O_8_35/iiif/manifest.json');
       setGlossary(
-        "https://editioncrafter.org-data/fr640_3r-3v-example/glossary.json"
+        "https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/glossary.json"
       );
       setTitle("Taos Baptisms Batch 2");
     }, 10000);


### PR DESCRIPTION
### In this PR
Fixes the URL pertaining to the data for the `fr640` example; the URLs now correctly start `cu-mkp.github.io/editioncrafter-data`. (They had gotten swept up in a find/replace when we switched to the custom domain.)