### PR TITLE
`dev` into `main`

### DIFF
--- a/editioncrafter-umd/package-lock.json
+++ b/editioncrafter-umd/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cu-mkp/editioncrafter-umd",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cu-mkp/editioncrafter-umd",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@cu-mkp/editioncrafter": "*",

--- a/editioncrafter-umd/package.json
+++ b/editioncrafter-umd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cu-mkp/editioncrafter-umd",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "https://editioncrafter.org/",
   "description": "A simple digital critical edition publication tool",
   "private": false,

--- a/editioncrafter/package-lock.json
+++ b/editioncrafter/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cu-mkp/editioncrafter",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cu-mkp/editioncrafter",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.12.4",

--- a/editioncrafter/package.json
+++ b/editioncrafter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cu-mkp/editioncrafter",
   "type": "module",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": false,
   "description": "A simple digital critical edition publication tool",
   "license": "MIT",

--- a/editioncrafter/src/RecordList/component/Record.jsx
+++ b/editioncrafter/src/RecordList/component/Record.jsx
@@ -18,7 +18,7 @@ function getTagObjects(ids, allTags) {
 
 function getSurfaceLink(baseUrl, div, cats, tags) {
   return (
-    `${baseUrl}&viewMode=story#/ec/${div.surface_xml_id}/f/${div.surface_xml_id}/${div.layer_xml_id}?tags=${[...cats, ...tags].join(',')}`
+    `${baseUrl}#/ec/${div.surface_xml_id}/f/${div.surface_xml_id}/${div.layer_xml_id}?tags=${[...cats, ...tags].join(',')}`
   )
 }
 

--- a/editioncrafter/stories/EditionCrafter.stories.jsx
+++ b/editioncrafter/stories/EditionCrafter.stories.jsx
@@ -139,7 +139,7 @@ export function RecordListExample() {
     <RecordList
       dbUrl="/database-example/example.sqlite"
       recordLabel="Entries"
-      viewerUrl="http://localhost:6006/iframe.html?globals=&id=editioncrafter--taxonomy-example"
+      viewerUrl="http://localhost:6006/iframe.html?globals=&id=editioncrafter--taxonomy-example&viewMode=story"
     />
   )
 }


### PR DESCRIPTION
# Summary

This PR contains a `RecordList` hotfix for a quick 1.2.1 release.

The function that determined which URL a `Record` card should link to erroneously included a Storybook parameter, breaking the feature outside of Storybook. Removing that param from the hardcoded part of the URL fixes the issue. 