### PR TITLE
Phrase support in Record List

### DIFF
--- a/editioncrafter/package-lock.json
+++ b/editioncrafter/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cu-mkp/editioncrafter",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cu-mkp/editioncrafter",
-      "version": "1.3.0-beta.1",
+      "version": "1.3.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.12.4",

--- a/editioncrafter/package-lock.json
+++ b/editioncrafter/package-lock.json
@@ -26,7 +26,7 @@
         "redux": "^4.2.1",
         "redux-saga": "^1.2.2",
         "remark-gfm": "^3.0.1",
-        "sql.js": "^1.12.0"
+        "sql.js": "^1.13.0"
       },
       "devDependencies": {
         "@antfu/eslint-config": "^3.8.0",
@@ -14390,9 +14390,9 @@
       "dev": true
     },
     "node_modules/sql.js": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.12.0.tgz",
-      "integrity": "sha512-Bi+43yMx/tUFZVYD4AUscmdL6NHn3gYQ+CM+YheFWLftOmrEC/Mz6Yh7E96Y2WDHYz3COSqT+LP6Z79zgrwJlA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.13.0.tgz",
+      "integrity": "sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==",
       "license": "MIT"
     },
     "node_modules/stable-hash": {

--- a/editioncrafter/package.json
+++ b/editioncrafter/package.json
@@ -47,7 +47,7 @@
     "redux": "^4.2.1",
     "redux-saga": "^1.2.2",
     "remark-gfm": "^3.0.1",
-    "sql.js": "^1.12.0"
+    "sql.js": "^1.13.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^3.8.0",

--- a/editioncrafter/src/RecordList/component/PhraseListTable.jsx
+++ b/editioncrafter/src/RecordList/component/PhraseListTable.jsx
@@ -1,0 +1,108 @@
+import { useContext, useMemo, useState } from 'react'
+import Pill from '../../common/components/Pill'
+import FilterContext from '../context/FilterContext'
+
+const MAX_PHRASE_LENGTH = 20
+
+function PhraseList(props) {
+  const phraseStr = useMemo(() => {
+    const arr = []
+
+    props.phrases.forEach((phrase) => {
+      if (phrase.layer !== props.layer) {
+        return
+      }
+
+      if (arr.includes(phrase.name)) {
+        return
+      }
+
+      if (phrase.name.length > MAX_PHRASE_LENGTH) {
+        arr.push(`${phrase.name.slice(0, MAX_PHRASE_LENGTH)}...`)
+      }
+      else {
+        arr.push(phrase.name)
+      }
+    })
+
+    return arr.join('; ')
+  }, [props.layer, props.phrases])
+
+  return <p>{phraseStr}</p>
+}
+
+function PhraseListTable(props) {
+  const ctx = useContext(FilterContext)
+
+  const [layer, setLayer] = useState(Object.keys(ctx.layers)[0])
+
+  const tagsToShow = useMemo(
+    () => Object.keys(props.tagCounts).filter(tagName => props.tagCounts[tagName].phrases.some(phrase => phrase.layer === layer)),
+    [layer, props.tagCounts],
+  )
+
+  return (
+    <div
+      className="phrase-list-table-container"
+      style={{ display: props.visible ? 'initial' : 'none' }}
+    >
+      <div className="layer-select-container">
+        <span>Layer</span>
+        <select
+          className="layer-select"
+          onChange={e => setLayer(e.target.value)}
+        >
+          {Object.keys(ctx.layers).map(xmlId => (
+            <option
+              key={xmlId}
+              value={xmlId}
+            >
+              {ctx.layers[xmlId]}
+            </option>
+          ))}
+        </select>
+      </div>
+      <table className="phrase-list-table">
+        <thead>
+          <tr>
+            <th>Tags for phrases</th>
+            <th>
+              <span>References in this layer</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {tagsToShow.length === 0 && (
+            <tr>
+              <td colSpan={2}>
+                <div className="empty-table-container">
+                  No tags in this layer.
+                </div>
+              </td>
+            </tr>
+          )}
+          {tagsToShow.map(tag => (
+            <tr key={tag}>
+              <td>
+                <Pill
+                  label={tag}
+                  isActive={ctx.tags.includes(props.tagCounts[tag].id)}
+                >
+                  <span className="tag-count">{props.tagCounts[tag].count}</span>
+                </Pill>
+              </td>
+              <td>
+                <PhraseList
+                  layer={layer}
+                  phrases={props.tagCounts[tag].phrases}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default PhraseListTable

--- a/editioncrafter/src/RecordList/component/Record.jsx
+++ b/editioncrafter/src/RecordList/component/Record.jsx
@@ -1,6 +1,8 @@
-import { useContext, useMemo } from 'react'
+import { useContext, useMemo, useState } from 'react'
+import { IoChevronDownOutline, IoChevronUpOutline } from 'react-icons/io5'
 import Pill from '../../common/components/Pill'
 import FilterContext from '../context/FilterContext'
+import PhraseList from './PhraseListTable'
 
 function getRecordName(div) {
   if (div.element_name) {
@@ -22,7 +24,24 @@ function getSurfaceLink(baseUrl, div, cats, tags) {
   )
 }
 
+function PhraseToggle(props) {
+  return (
+    <button
+      aria-label="Toggle phrases"
+      className="phrase-toggle"
+      onClick={props.onClick}
+      type="button"
+    >
+      {props.toggled
+        ? <IoChevronUpOutline />
+        : <IoChevronDownOutline />}
+    </button>
+  )
+}
+
 function Record(props) {
+  const [showPhrases, setShowPhrases] = useState(false)
+
   const ctx = useContext(FilterContext)
 
   const categories = useMemo(
@@ -38,11 +57,19 @@ function Record(props) {
       tags.forEach((tag) => {
         if (result[tag.name]) {
           result[tag.name].count++
+          result[tag.name].phrases.push({
+            name: el.element_name,
+            layer: el.layer_xml_id,
+          })
         }
         else {
           result[tag.name] = {
             id: tag.xml_id,
             count: 1,
+            phrases: [{
+              name: el.element_name,
+              layer: el.layer_xml_id,
+            }],
           }
         }
       })
@@ -74,7 +101,16 @@ function Record(props) {
             <span className="tag-count">{tagCounts[tagName].count}</span>
           </Pill>
         ))}
+        <PhraseToggle
+          toggled={showPhrases}
+          onClick={() => setShowPhrases(!showPhrases)}
+        />
       </div>
+      <PhraseList
+        tagCounts={tagCounts}
+        elements={props.childElements}
+        visible={showPhrases}
+      />
     </div>
   )
 }

--- a/editioncrafter/src/RecordList/index.jsx
+++ b/editioncrafter/src/RecordList/index.jsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import initSqlJs from 'sql.js'
+import sqlJsInfo from 'sql.js/package.json'
 import Loading from '../common/components/Loading'
 import RecordListView from './component/RecordListView'
 import Sidebar from './component/Sidebar'
-
 import FilterContext from './context/FilterContext'
 
 import './styles/base.css'
@@ -26,7 +26,7 @@ async function initDb(url) {
   const arr = new Uint8Array(buf)
 
   const SQL = await initSqlJs({
-    locateFile: file => `https://sql.js.org/dist/${file}`,
+    locateFile: file => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/${sqlJsInfo.version}/${file}`,
   })
 
   const db = new SQL.Database(arr)
@@ -56,7 +56,8 @@ function RecordList(props) {
     ...filters,
     toggleCategoryFilter,
     toggleTagFilter,
-  }), [filters, toggleCategoryFilter, toggleTagFilter])
+    layers: props.layers,
+  }), [filters, toggleCategoryFilter, toggleTagFilter, props.layers])
 
   useEffect(() => {
     const loadDb = async () => {
@@ -83,7 +84,11 @@ function RecordList(props) {
     <FilterContext.Provider value={initialContext}>
       <div className="editioncrafter-record-list">
         <Sidebar db={db} />
-        <RecordListView db={db} recordLabel={props.recordLabel} viewerUrl={props.viewerUrl} />
+        <RecordListView
+          db={db}
+          recordLabel={props.recordLabel}
+          viewerUrl={props.viewerUrl}
+        />
       </div>
     </FilterContext.Provider>
   )

--- a/editioncrafter/src/RecordList/styles/base.css
+++ b/editioncrafter/src/RecordList/styles/base.css
@@ -3,7 +3,8 @@
 .editioncrafter-record-list {
   width: 100%;
   height: 100%;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr;
   gap: 20px;
   font-family: 'Inter', sans-serif;
   margin: 0;

--- a/editioncrafter/src/RecordList/styles/record.css
+++ b/editioncrafter/src/RecordList/styles/record.css
@@ -36,13 +36,34 @@
   align-items: center;
   font-size: 14px;
   font-weight: 500;
+  position: relative;
 }
 
 .editioncrafter-record-list .record-list-view .record-box .tag-list .tag-list-label {
   font-weight: 600;
 }
 
-.editioncrafter-record-list .record-list-view .record-box .tag-list .pill {
+.editioncrafter-record-list .record-list-view .record-box .phrase-toggle {
+  position: absolute;
+  right: 0;
+  bottom: 2px;
+  background: #07529A;
+  border: none;
+  border-radius: 5px;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px;
+}
+
+.editioncrafter-record-list .record-list-view .record-box .phrase-toggle svg {
+  height: 18px;
+  width: 18px;
+}
+
+.editioncrafter-record-list .record-list-view .record-box .tag-list .pill,
+.editioncrafter-record-list .record-list-view .record-box .phrase-list-table .pill {
   background: #ffffff;
   display: flex;
   height: 32px;
@@ -59,7 +80,7 @@
   color: #ffffff
 }
 
-.editioncrafter-record-list .record-list-view .record-box .tag-list .pill .tag-count {
+.editioncrafter-record-list .record-list-view .record-box .pill .tag-count {
   display: inline-flex;
   height: 24px;
   min-width: 24px;
@@ -73,12 +94,79 @@
   background: #B5C8DC99;
 }
 
-.editioncrafter-record-list .record-list-view .record-box .tag-list .pill.active {
+.editioncrafter-record-list .record-list-view .record-box .pill.active {
   border: 1px solid #07529A;
   color: #07529A;
 }
 
-.editioncrafter-record-list .record-list-view .record-box .tag-list .pill.active .tag-count {
+.editioncrafter-record-list .record-list-view .record-box .pill.active .tag-count {
   background: #07529A;
   color: #ffffff;
+}
+
+.editioncrafter-record-list .record-list-view .record-box .phrase-list-table-container {
+  position: relative;
+}
+
+.editioncrafter-record-list .record-list-view .record-box .phrase-list-table-container .layer-select-container {
+  position: absolute;
+  right: 10px;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 140%;
+}
+
+.editioncrafter-record-list .record-list-view .record-box .phrase-list-table-container button:hover {
+  cursor: default;
+}
+
+.editioncrafter-record-list .record-list-view .record-box .phrase-list-table-container .layer-select {
+  display: flex;
+  height: 32px;
+  padding: 0px 12px;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 14px;
+  border-radius: 4px;
+  border: 1px solid#E1E3E6;
+  background:#F3F4F7;
+}
+
+.editioncrafter-record-list .record-list-view .record-box .phrase-list-table-container .layer-select:hover {
+  cursor: pointer;
+}
+
+.editioncrafter-record-list .record-list-view .record-box .phrase-list-table th {
+  font-weight: 600;
+}
+
+.editioncrafter-record-list .record-list-view .record-box .phrase-list-table {
+  text-align: left;
+  border-collapse: collapse;
+  font-size: 14px;
+  width: 100%;
+}
+
+.editioncrafter-record-list .record-list-view .record-box .phrase-list-table tr {
+  border-bottom: 1px solid #E1E3E6;
+}
+
+.editioncrafter-record-list .record-list-view .record-box .phrase-list-table td,
+.editioncrafter-record-list .record-list-view .record-box .phrase-list-table th {
+  padding: 12px;
+
+}
+
+.editioncrafter-record-list .record-list-view .record-box .phrase-list-table .empty-table-container {
+  height: 80px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/editioncrafter/src/TagExplore/index.jsx
+++ b/editioncrafter/src/TagExplore/index.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { HashRouter } from 'react-router-dom'
 import initSqlJs from 'sql.js'
+import sqlJsInfo from 'sql.js/package.json'
 import Loading from '../common/components/Loading'
 import { getObjs } from '../common/lib/sql'
 import EditionCrafter from '../EditionCrafter'
@@ -24,7 +25,7 @@ async function initDb(url) {
   const arr = new Uint8Array(buf)
 
   const db = await initSqlJs({
-    locateFile: file => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.12.0/${file}`,
+    locateFile: file => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/${sqlJsInfo.version}/${file}`,
   }).then((SQL) => {
     const db = new SQL.Database(arr)
     return db

--- a/editioncrafter/stories/EditionCrafter.stories.jsx
+++ b/editioncrafter/stories/EditionCrafter.stories.jsx
@@ -4,35 +4,35 @@ import EditionCrafter, { RecordList, TagExplore } from '../src/index'
 export function ElyGreenVariorum() {
   return (
     <EditionCrafter
-      documentName='Ely Green Variorum'
-      // notesURL="http://localhost:4321/alignment.md"
+      documentName="Ely Green Variorum"
+      notesURL="https://digitalelygreen.org/explore/alignment.md"
       documentInfo={{
-          egA: {
-            documentName: 'EG A',
-            transcriptionTypes: {
-              'text': 'Transcription'
-            },
-            iiifManifest: 'https://faircopy.cloud/documents/eg-a/iiif/manifest.json'
+        egA: {
+          documentName: 'EG A',
+          transcriptionTypes: {
+            text: 'Transcription',
           },
-          egB: {
-            documentName: 'EG B',
-            transcriptionTypes: {
-              'DerivativeB': 'Transcription'
-            },
-            iiifManifest: 'https://faircopy.cloud/documents/eg-b/iiif/manifest.json'
+          iiifManifest: 'https://faircopy.cloud/documents/eg-a/iiif/manifest.json',
+        },
+        egB: {
+          documentName: 'EG B',
+          transcriptionTypes: {
+            DerivativeB: 'Transcription',
           },
-          ElyGreenMS: {
-            documentName: 'ElyGreen MS',
-            transcriptionTypes: {
-              'transcription': 'Transcription'
-            },
-            iiifManifest: 'https://faircopy.cloud/documents/ElyGreenMS/iiif/manifest.json'
+          iiifManifest: 'https://faircopy.cloud/documents/eg-b/iiif/manifest.json',
+        },
+        ElyGreenMS: {
+          documentName: 'ElyGreen MS',
+          transcriptionTypes: {
+            transcription: 'Transcription',
           },
+          iiifManifest: 'https://faircopy.cloud/documents/ElyGreenMS/iiif/manifest.json',
+        },
       }}
       client:only
       threePanel
       transition:persist
-  />
+    />
   )
 }
 
@@ -175,6 +175,12 @@ export function RecordListExample() {
     <RecordList
       dbUrl="/database-example/example.sqlite"
       recordLabel="Entries"
+      layers={{
+        tc: 'Diplomatic (FR)',
+        tcn: 'Normalized (FR)',
+        tl: 'Translation (EN)',
+        test: 'Test Field (EN)',
+      }}
       viewerUrl="http://localhost:6006/iframe.html?globals=&id=editioncrafter--taxonomy-example&viewMode=story"
     />
   )


### PR DESCRIPTION
# Summary

This PR adds a new list of phrases to each result item in the Record List component.

It also updates the way `TagExplore` fetches its `sql.js` WASM file to be based on the currently installed version of `sql.js` instead of being hardcoded.