### PR TITLE
Update `TranscriptionView` to read new tag arrays from `TagFilterContext`

### DIFF
--- a/editioncrafter/src/EditionCrafter/component/TranscriptionView.js
+++ b/editioncrafter/src/EditionCrafter/component/TranscriptionView.js
@@ -107,8 +107,6 @@ function htmlToReactParserOptions(selectedZone, selectedTags) {
 function TranscriptionView(props) {
   const [searchParams] = useSearchParams()
 
-  const { tags } = useContext(TagFilterContext)
-
   const {
     side,
     folioID,
@@ -117,6 +115,9 @@ function TranscriptionView(props) {
     documentView,
     documentViewActions,
   } = props
+
+  const { tagsLeft, tagsRight } = useContext(TagFilterContext)
+  const tags = side === 'left' ? tagsLeft : tagsRight
 
   if (folioID === '-1') {
     return (


### PR DESCRIPTION
# Summary

#161 replaced the `tags` array in `TagFilterContext` with two arrays, `tagsRight` and `tagsLeft`, but the `TranscriptionView` component was still trying to access `tags`, causing its `htmlToReactParserOptions` function to crash due to `tags` being undefined.

This PR updates `TranscriptionView` to use one of the new tags arrays corresponding to its side.